### PR TITLE
chore: use Preview-Close for PR closed preview sync

### DIFF
--- a/.github/workflows/infra-preview-domains.yml
+++ b/.github/workflows/infra-preview-domains.yml
@@ -14,7 +14,7 @@ jobs:
   sync-preview-domains:
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
-    environment: Preview
+    environment: ${{ github.event.action == 'closed' && 'Preview-Close' || 'Preview' }}
     permissions:
       contents: read
       deployments: read


### PR DESCRIPTION
## Summary\n- route pull_request.closed runs of infra preview domain sync to `Preview-Close` environment\n- keep other pull_request actions on `Preview`\n\n## Why\n- avoid approval requirement on closed trigger while preserving existing approvals for non-closed PR events