### PR TITLE
fix(sentence): 单词加载失败时显示真实错误而非误报单词不足

### DIFF
--- a/apps/web/src/app/sentence/page.tsx
+++ b/apps/web/src/app/sentence/page.tsx
@@ -7,7 +7,7 @@ import Link from "next/link";
 import { useEffect, useState, type FormEvent } from "react";
 
 const Sentence = observer(() => {
-  const { loading, question, feedback, generating, checking, error, generate, check, words, syncing, pendingCount, syncToFirestore } = useSentencePractice();
+  const { loading, loadError, question, feedback, generating, checking, error, generate, check, words, syncing, pendingCount, syncToFirestore } = useSentencePractice();
   const { t } = useLocale();
   const [answer, setAnswer] = useState("");
   const [isClient, setIsClient] = useState(false);
@@ -60,10 +60,16 @@ const Sentence = observer(() => {
 
         {noWords ? (
           <div className="text-center space-y-4">
-            <p className="text-gray-500">{t("sentence.needMoreWords")}</p>
-            <Button asChild>
-              <Link href="/add-word">{t("addWord.title")}</Link>
-            </Button>
+            {loadError ? (
+              <p className="text-red-500">{loadError}</p>
+            ) : (
+              <>
+                <p className="text-gray-500">{t("sentence.needMoreWords")}</p>
+                <Button asChild>
+                  <Link href="/add-word">{t("addWord.title")}</Link>
+                </Button>
+              </>
+            )}
           </div>
         ) : (
           <div className="space-y-4">

--- a/apps/web/src/hooks/useSentencePractice.ts
+++ b/apps/web/src/hooks/useSentencePractice.ts
@@ -150,6 +150,7 @@ export const useSentencePractice = () => {
   return {
     words,
     loading: firestore.loading,
+    loadError: firestore.error,
     question,
     feedback,
     generating,


### PR DESCRIPTION
## 问题

造句练习页有时显示"词汇库单词不足"。实际原因是 `useFirestoreWords` 的 `onSnapshot` 出错（网络波动、Firestore 离线等）时，`loading` 被置为 false 且 `wordData` 为空，页面把加载失败误报成了"单词不足"——`useSentencePractice` 没有透出 `firestore.error`，页面无从区分两种情况。

## 改动

- `useSentencePractice` 返回值新增 `loadError: firestore.error`
- 造句练习页在词库为空时：有 `loadError` 则显示真实的加载错误（红色），否则才显示"单词不足"提示和添加单词按钮

已验证 `tsc --noEmit` 与 `eslint` 通过。