### PR TITLE
perf: 词库状态管理与同步链路性能优化

### DIFF
--- a/.github/workflows/sync-preview-words.yml
+++ b/.github/workflows/sync-preview-words.yml
@@ -2,7 +2,7 @@ name: Sync Preview Words
 
 on:
   schedule:
-    - cron: "*/30 * * * *"
+    - cron: "0 */6 * * * *"
   workflow_dispatch:
 
 jobs:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,5 +22,5 @@
 ## 预览环境与 sync-preview-words
 
 - Vercel preview 环境使用匿名登录，`getEffectiveUserId` 会把所有用户映射到 `preview` 用户，读写 `users/preview/*`。
-- `scripts/sync-preview-words.mjs` 定时把生产用户词库复制到 `users/preview`，这是**有意设计**，为了让 preview 环境始终有可练习的真实数据，不要把它当作冗余任务优化掉。
+- `scripts/sync-preview-words.mjs` 定时把生产用户词库复制到 `users/preview`（diff 增量同步，每 6 小时一次），这是**有意设计**，为了让 preview 环境始终有可练习的真实数据，不要把它当作冗余任务优化掉。
 - `users/preview` 的 Firestore 规则：读对任何已登录用户开放，写仅限匿名用户（`sign_in_provider == 'anonymous'`），防止正式环境的 Google 用户越权篡改 preview 数据。

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -2,6 +2,12 @@
 
 本文件包含 AI 在本项目中工作时必须遵守的规则和项目信息。
 
+## 词库状态管理
+
+- `src/hooks/useFirestoreWords.tsx`：`Words` 是模块级 MobX 单例 store；`WordsProvider`（挂在根 layout）在登录后全局只做一次 `onSnapshot` 订阅，`useFirestoreWords` 只是读 Context，不要在页面里再订阅 Firestore。
+- 熟练度结果通过 `#masteryCache` 缓存（随 `recordCorrect/IncorrectAttempt`、`setWords` 失效），全量统计用 computed getter（`overallAverageInputTime`、`averageTimeByLengthCategory`、`practiceStats`），新增派生数据时优先用 computed getter 而非每次渲染重算。
+- 练习页的输入值在 `words.userInputs` 中，单词行是独立的 observer 组件（`WordRow`），只有对应行会随击键重渲染，不要在父组件渲染路径里读 `userInputs`。
+
 ## 造句练习与 DeepSeek 集成
 
 - 造句/批改功能通过服务端 Route Handler（`src/app/api/sentence/*`）代理调用 DeepSeek，浏览器只请求本站 `/api/*`。

--- a/apps/web/src/app/add-word/page.tsx
+++ b/apps/web/src/app/add-word/page.tsx
@@ -23,7 +23,7 @@ const Home = () => {
 
     setLoading(true);
 
-    if (words.allWords.has(word)) {
+    if (words.wordData.has(word)) {
       toast({ title: t('addWord.wordExists').replace('{word}', word), variant: "destructive" });
       clear();
       setLoading(false);

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -7,6 +7,7 @@ import type { Metadata } from "next";
 import { FC, ReactNode } from "react";
 import { AuthProvider } from "@/components/auth";
 import { AppShell } from "@/components/auth/AppShell";
+import { WordsProvider } from "@/hooks";
 import { Toaster } from "@/components/ui";
 import { detectLocaleFromAcceptLanguage, localeToHtmlLang } from "@/lib/i18n";
 
@@ -30,10 +31,12 @@ const RootLayout: FC<{ children: ReactNode }> = async ({ children }) => {
     <html lang={localeToHtmlLang(locale)} className={`${inter.variable} ${notoSansSC.variable}`}>
       <body className="flex min-h-screen flex-col antialiased">
         <AuthProvider>
-          <AppShell>
-            {children}
-          </AppShell>
-          <Toaster />
+          <WordsProvider>
+            <AppShell>
+              {children}
+            </AppShell>
+            <Toaster />
+          </WordsProvider>
         </AuthProvider>
         <Analytics />
       </body>

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -41,8 +41,8 @@ const Profile = observer(() => {
     setIsClient(true);
   }, []);
 
-  const totalWords = words.allWords.size;
-  const overallAverageTime = words.getOverallAverageInputTime();
+  const totalWords = words.wordData.size;
+  const overallAverageTime = words.overallAverageInputTime;
 
   const wordsWithStats = words.practiceStats;
 
@@ -241,7 +241,7 @@ const Profile = observer(() => {
               { category: 1, labelKey: "profile.mediumWords", color: "yellow" },
               { category: 2, labelKey: "profile.longWords", color: "red" },
             ] as const).map(({ category, labelKey, color }) => {
-              const avgTime = words.getAverageTimeByLengthCategory(category);
+              const avgTime = words.averageTimeByLengthCategory[category];
               const categoryWords = filteredWordsByCategory[category];
               const classes = COLOR_CLASSES[color as keyof typeof COLOR_CLASSES];
               

--- a/apps/web/src/app/sentence/page.tsx
+++ b/apps/web/src/app/sentence/page.tsx
@@ -12,7 +12,7 @@ const Sentence = observer(() => {
   const [answer, setAnswer] = useState("");
   const [isClient, setIsClient] = useState(false);
   const [hasTriedInitialGenerate, setHasTriedInitialGenerate] = useState(false);
-  const noWords = words.allWords.size < 2;
+  const noWords = words.wordData.size < 2;
 
   useEffect(() => {
     setIsClient(true);

--- a/apps/web/src/app/words/page.tsx
+++ b/apps/web/src/app/words/page.tsx
@@ -1,10 +1,156 @@
 "use client";
 
 import { Input, Button, MasteryBar, SyncIndicator } from "@/components/ui";
-import { useEffect, useState, useRef, type FormEvent } from "react";
+import { useCallback, useEffect, useState, useRef, type FormEvent, type RefObject } from "react";
 import { observer } from "mobx-react-lite";
 import Link from "next/link";
 import { useFirestoreWords, useLocale, toast } from "@/hooks";
+import type { Words } from "@/hooks/useFirestoreWords";
+import type { TranslationKey } from "@/lib/i18n";
+
+const parseTranslation = (translation: string) => {
+  const segments = translation
+    .split("\n")
+    .map((segment) => segment.trim())
+    .filter(Boolean);
+
+  if (segments.length === 0) {
+    return { englishDefinition: "", chineseTranslation: "" };
+  }
+
+  if (segments.length === 1) {
+    const single = segments[0];
+    const hasChinese = /[\u4e00-\u9fff]/.test(single);
+    return hasChinese ? { englishDefinition: "", chineseTranslation: single } : { englishDefinition: single, chineseTranslation: "" };
+  }
+
+  return {
+    englishDefinition: segments[0],
+    chineseTranslation: segments.slice(1).join("\n"),
+  };
+};
+
+interface WordRowProps {
+  word: string;
+  translation: string;
+  words: Words;
+  isEditing: boolean;
+  editingValue: string;
+  onEditingValueChange: (value: string) => void;
+  onStartEdit: (word: string, englishDefinition: string, chineseTranslation: string) => void;
+  onCommitEdit: () => void;
+  onCancelEdit: () => void;
+  onInputChange: (word: string, value: string) => void;
+  onHintReveal: (word: string) => void;
+  inputRefs: RefObject<Map<string, HTMLInputElement>>;
+  t: (key: TranslationKey) => string;
+}
+
+const WordRow = observer(({ word, translation, words, isEditing, editingValue, onEditingValueChange, onStartEdit, onCommitEdit, onCancelEdit, onInputChange, onHintReveal, inputRefs, t }: WordRowProps) => {
+  const inputValue = words.userInputs.get(word) || "";
+  const { englishDefinition, chineseTranslation } = parseTranslation(translation);
+
+  return (
+    <li className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-x-2 gap-y-1">
+      <div className="max-w-xs w-full text-right justify-self-end">
+        {isEditing ? (
+          <Input
+            className="w-full text-right"
+            type="text"
+            value={editingValue}
+            autoFocus
+            onChange={(e) => onEditingValueChange(e.target.value)}
+            onBlur={() => {
+              onCommitEdit();
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                if (e.nativeEvent.isComposing) {
+                  return;
+                }
+                e.preventDefault();
+                onCommitEdit();
+              }
+
+              if (e.key === "Escape") {
+                e.preventDefault();
+                onCancelEdit();
+              }
+            }}
+          />
+        ) : (
+          <div
+            className={`h-9 px-3 py-1 flex items-center justify-end whitespace-pre-line ${chineseTranslation ? "font-semibold" : "text-gray-400 italic"} cursor-pointer focus:outline-none focus:ring-2 focus:ring-blue-500 focus:rounded`}
+            onDoubleClick={() => onStartEdit(word, englishDefinition, chineseTranslation)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                onStartEdit(word, englishDefinition, chineseTranslation);
+              }
+            }}
+            title={t("home.editTranslationHint")}
+          >
+            {chineseTranslation || t("home.addChineseTranslation")}
+          </div>
+        )}
+      </div>
+      <div className="flex items-center space-x-2">
+        <Input
+          className="w-xs"
+          type="text"
+          id={word}
+          ref={(el) => {
+            if (el) {
+              inputRefs.current.set(word, el);
+            }
+          }}
+          onChange={(e) => onInputChange(word, e.target.value.toLowerCase())}
+          value={inputValue}
+        />
+        <button
+          type="button"
+          title={word}
+          aria-label={`${t("home.hint")}: ${word}`}
+          disabled={inputValue === word}
+          className={`${inputValue === word ? "" : "cursor-pointer focus:outline-none focus:ring-2 focus:ring-blue-500 focus:rounded"} px-1 relative group disabled:cursor-default`}
+          onMouseEnter={() => {
+            if (inputValue !== "" && inputValue !== word) {
+              onHintReveal(word);
+            }
+          }}
+          onFocus={() => {
+            if (inputValue !== "" && inputValue !== word) {
+              onHintReveal(word);
+            }
+          }}
+          onClick={() => {
+            if (inputValue !== word) {
+              onHintReveal(word);
+              const utterance = new SpeechSynthesisUtterance(word);
+              utterance.lang = "en-US";
+              speechSynthesis.speak(utterance);
+            }
+          }}
+        >
+          {inputValue === word ? "✅" : "❌"}
+          {inputValue !== word && <div className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 px-3 py-2 bg-gray-800 text-white text-sm rounded-lg opacity-0 group-hover:opacity-100 group-focus:opacity-100 transition-opacity duration-200 pointer-events-none whitespace-nowrap z-10">{word}</div>}
+        </button>
+        <MasteryBar score={words.getMasteryScore(word)} />
+      </div>
+      {englishDefinition && <div className="max-w-xs w-full text-right text-sm text-gray-500 whitespace-pre-line justify-self-end">{englishDefinition}</div>}
+      {englishDefinition && <div />}
+    </li>
+  );
+});
+
+const SubmitButton = observer(({ randomWords, words, label }: { randomWords: [string, string][]; words: Words; label: string }) => {
+  const allCorrect = randomWords.length > 0 && randomWords.every(([word]) => words.userInputs.get(word) === word);
+  return (
+    <Button type="submit" disabled={!allCorrect}>
+      {label}
+    </Button>
+  );
+});
 
 const WordsPractice = observer(() => {
   const { words, recordCorrectAttempt, recordIncorrectAttempt, syncToFirestore, syncing, pendingCount, loading, error, updateTranslation } = useFirestoreWords();
@@ -35,11 +181,11 @@ const WordsPractice = observer(() => {
 
   // Initialize random words when words are loaded
   useEffect(() => {
-    if (!loading && words.allWords.size > 0 && randomWords.length === 0) {
+    if (!loading && words.wordData.size > 0 && randomWords.length === 0) {
       setRandomWords(words.getRandomWords());
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [loading, words.allWords.size, randomWords.length]);
+  }, [loading, words.wordData.size, randomWords.length]);
 
   useEffect(() => {
     if (shouldFocusFirst && randomWords.length > 0) {
@@ -62,29 +208,7 @@ const WordsPractice = observer(() => {
     setShouldFocusFirst(true);
   };
 
-  const parseTranslation = (translation: string) => {
-    const segments = translation
-      .split("\n")
-      .map((segment) => segment.trim())
-      .filter(Boolean);
-
-    if (segments.length === 0) {
-      return { englishDefinition: "", chineseTranslation: "" };
-    }
-
-    if (segments.length === 1) {
-      const single = segments[0];
-      const hasChinese = /[\u4e00-\u9fff]/.test(single);
-      return hasChinese ? { englishDefinition: "", chineseTranslation: single } : { englishDefinition: single, chineseTranslation: "" };
-    }
-
-    return {
-      englishDefinition: segments[0],
-      chineseTranslation: segments.slice(1).join("\n"),
-    };
-  };
-
-  const startEditingTranslation = (word: string, englishDefinition: string, chineseTranslation: string) => {
+  const startEditingTranslation = useCallback((word: string, englishDefinition: string, chineseTranslation: string) => {
     setEditingWord(word);
     setEditingValue(chineseTranslation);
     editSessionRef.current = {
@@ -93,9 +217,9 @@ const WordsPractice = observer(() => {
       englishDefinition,
       committed: false,
     };
-  };
+  }, []);
 
-  const cancelEditingTranslation = () => {
+  const cancelEditingTranslation = useCallback(() => {
     setEditingWord(null);
     setEditingValue("");
     editSessionRef.current = {
@@ -104,9 +228,9 @@ const WordsPractice = observer(() => {
       englishDefinition: "",
       committed: false,
     };
-  };
+  }, []);
 
-  const commitEditingTranslation = async () => {
+  const commitEditingTranslation = useCallback(async () => {
     const session = editSessionRef.current;
     if (!session.word || session.committed) {
       return;
@@ -145,27 +269,54 @@ const WordsPractice = observer(() => {
         variant: "destructive",
       });
     }
-  };
+  }, [editingValue, t, updateTranslation, cancelEditingTranslation]);
 
-  const isCorrect = () => {
-    return randomWords.length > 0 && randomWords.every(([word]) => words.userInputs.get(word) === word);
-  };
-
-  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    if (!isCorrect()) {
-      return;
+  const handleInputChange = useCallback((word: string, value: string) => {
+    // Start timer on first character typed
+    if (value.length === 1) {
+      timerStartRef.current.set(word, Date.now());
     }
 
-    refreshWords();
-  };
+    // Clear timer if user clears input
+    if (value.length === 0) {
+      timerStartRef.current.delete(word);
+    }
 
-  const handleHintReveal = (word: string) => {
+    words.setUserInput(word, value);
+
+    if (value.length >= word.length && value !== word && !incorrectRecordedRef.current.has(word)) {
+      incorrectRecordedRef.current.add(word);
+      recordIncorrectAttempt(word);
+    }
+
+    // If word is now correct, record the attempt
+    if (value === word) {
+      const startTime = timerStartRef.current.get(word);
+
+      if (startTime) {
+        const inputTimeSeconds = (Date.now() - startTime) / 1000;
+        recordCorrectAttempt(word, inputTimeSeconds);
+        timerStartRef.current.delete(word);
+      }
+    }
+  }, [words, recordCorrectAttempt, recordIncorrectAttempt]);
+
+  const handleHintReveal = useCallback((word: string) => {
     // Only record incorrect attempt once per word per session
     if (!incorrectRecordedRef.current.has(word)) {
       incorrectRecordedRef.current.add(word);
       recordIncorrectAttempt(word);
     }
+  }, [recordIncorrectAttempt]);
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const allCorrect = randomWords.length > 0 && randomWords.every(([word]) => words.userInputs.get(word) === word);
+    if (!allCorrect) {
+      return;
+    }
+
+    refreshWords();
   };
 
   if (loading) {
@@ -198,142 +349,27 @@ const WordsPractice = observer(() => {
         <main>
           <form onSubmit={handleSubmit} className="flex flex-col space-y-2">
             <ul className="space-y-2">
-              {randomWords.map(([word, translation]) => {
-                const inputValue = words.userInputs.get(word) || "";
-                const { englishDefinition, chineseTranslation } = parseTranslation(translation);
-                const isEditingTranslation = editingWord === word;
-
-                return (
-                  <li key={word} className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-x-2 gap-y-1">
-                    <div className="max-w-xs w-full text-right justify-self-end">
-                      {isEditingTranslation ? (
-                        <Input
-                          className="w-full text-right"
-                          type="text"
-                          value={editingValue}
-                          autoFocus
-                          onChange={(e) => setEditingValue(e.target.value)}
-                          onBlur={() => {
-                            commitEditingTranslation();
-                          }}
-                          onKeyDown={(e) => {
-                            if (e.key === "Enter") {
-                              if (e.nativeEvent.isComposing) {
-                                return;
-                              }
-                              e.preventDefault();
-                              commitEditingTranslation();
-                            }
-
-                            if (e.key === "Escape") {
-                              e.preventDefault();
-                              cancelEditingTranslation();
-                            }
-                          }}
-                        />
-                      ) : (
-                        <div
-                          className={`h-9 px-3 py-1 flex items-center justify-end whitespace-pre-line ${chineseTranslation ? "font-semibold" : "text-gray-400 italic"} cursor-pointer focus:outline-none focus:ring-2 focus:ring-blue-500 focus:rounded`}
-                          onDoubleClick={() => startEditingTranslation(word, englishDefinition, chineseTranslation)}
-                          onKeyDown={(e) => {
-                            if (e.key === "Enter" || e.key === " ") {
-                              e.preventDefault();
-                              startEditingTranslation(word, englishDefinition, chineseTranslation);
-                            }
-                          }}
-                          title={t("home.editTranslationHint")}
-                        >
-                          {chineseTranslation || t("home.addChineseTranslation")}
-                        </div>
-                      )}
-                    </div>
-                    <div className="flex items-center space-x-2">
-                      <Input
-                        className="w-xs"
-                        type="text"
-                        id={word}
-                        ref={(el) => {
-                          if (el) {
-                            inputRefs.current.set(word, el);
-                          }
-                        }}
-                        onChange={(e) => {
-                          const value = e.target.value.toLowerCase();
-
-                          // Start timer on first character typed
-                          if (value.length === 1) {
-                            timerStartRef.current.set(word, Date.now());
-                          }
-
-                          // Clear timer if user clears input
-                          if (value.length === 0) {
-                            timerStartRef.current.delete(word);
-                          }
-
-                          words.setUserInput(word, value);
-
-                          if (value.length >= word.length && value !== word && !incorrectRecordedRef.current.has(word)) {
-                            incorrectRecordedRef.current.add(word);
-                            recordIncorrectAttempt(word);
-                          }
-
-                          // If word is now correct, record the attempt
-                          if (value === word) {
-                            const startTime = timerStartRef.current.get(word);
-
-                            if (startTime) {
-                              const endTime = Date.now();
-                              const inputTimeSeconds = (endTime - startTime) / 1000;
-
-                              // Record correct attempt with input time
-                              recordCorrectAttempt(word, inputTimeSeconds);
-
-                              timerStartRef.current.delete(word);
-                            }
-                          }
-                        }}
-                        value={inputValue}
-                      />
-                      <button
-                        type="button"
-                        title={word}
-                        aria-label={`${t("home.hint")}: ${word}`}
-                        disabled={inputValue === word}
-                        className={`${inputValue === word ? "" : "cursor-pointer focus:outline-none focus:ring-2 focus:ring-blue-500 focus:rounded"} px-1 relative group disabled:cursor-default`}
-                        onMouseEnter={() => {
-                          if (inputValue !== "" && inputValue !== word) {
-                            handleHintReveal(word);
-                          }
-                        }}
-                        onFocus={() => {
-                          if (inputValue !== "" && inputValue !== word) {
-                            handleHintReveal(word);
-                          }
-                        }}
-                        onClick={() => {
-                          if (inputValue !== word) {
-                            handleHintReveal(word);
-                            const utterance = new SpeechSynthesisUtterance(word);
-                            utterance.lang = "en-US";
-                            speechSynthesis.speak(utterance);
-                          }
-                        }}
-                      >
-                        {inputValue === word ? "✅" : "❌"}
-                        {inputValue !== word && <div className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 px-3 py-2 bg-gray-800 text-white text-sm rounded-lg opacity-0 group-hover:opacity-100 group-focus:opacity-100 transition-opacity duration-200 pointer-events-none whitespace-nowrap z-10">{word}</div>}
-                      </button>
-                      <MasteryBar score={words.getMasteryScore(word)} />
-                    </div>
-                    {englishDefinition && <div className="max-w-xs w-full text-right text-sm text-gray-500 whitespace-pre-line justify-self-end">{englishDefinition}</div>}
-                    {englishDefinition && <div />}
-                  </li>
-                );
-              })}
+              {randomWords.map(([word, translation]) => (
+                <WordRow
+                  key={word}
+                  word={word}
+                  translation={translation}
+                  words={words}
+                  isEditing={editingWord === word}
+                  editingValue={editingWord === word ? editingValue : ""}
+                  onEditingValueChange={setEditingValue}
+                  onStartEdit={startEditingTranslation}
+                  onCommitEdit={commitEditingTranslation}
+                  onCancelEdit={cancelEditingTranslation}
+                  onInputChange={handleInputChange}
+                  onHintReveal={handleHintReveal}
+                  inputRefs={inputRefs}
+                  t={t}
+                />
+              ))}
             </ul>
             <div className="flex space-x-2 justify-end">
-              <Button type="submit" disabled={!isCorrect()}>
-                {t("home.refresh")}
-              </Button>
+              <SubmitButton randomWords={randomWords} words={words} label={t("home.refresh")} />
               <Button asChild type="button" variant="outline">
                 <Link href="/add-word">{t("addWord.title")}</Link>
               </Button>

--- a/apps/web/src/hooks/index.ts
+++ b/apps/web/src/hooks/index.ts
@@ -1,4 +1,4 @@
-export { useFirestoreWords } from "./useFirestoreWords";
+export { useFirestoreWords, WordsProvider } from "./useFirestoreWords";
 export { useSentencePractice } from "./useSentencePractice";
 export { useLocale } from "./useLocale";
 export { useToast, toast } from "./useToast";

--- a/apps/web/src/hooks/useFirestoreWords.tsx
+++ b/apps/web/src/hooks/useFirestoreWords.tsx
@@ -1,6 +1,15 @@
 "use client";
 
-import { useEffect, useState, useRef } from "react";
+import {
+  useEffect,
+  useState,
+  useCallback,
+  useMemo,
+  useContext,
+  createContext,
+  type FC,
+  type ReactNode,
+} from "react";
 import {
   collection,
   addDoc,
@@ -42,7 +51,7 @@ interface WordData {
   id: string;
 }
 
-class Words {
+export class Words {
   static MAX_RANDOM_WORDS = 5;
   static MAX_INPUT_TIMES = 20;
   static MAX_CORRECT_PRACTICE_DATES = 30;
@@ -50,6 +59,7 @@ class Words {
   wordData: Map<string, WordData> = new Map();
   userInputs: Map<string, string> = new Map();
   #priorityCache = new Map<string, { masteryScore: number; priority: number }>();
+  #masteryCache = new Map<string, MasteryResult>();
 
   constructor() {
     makeAutoObservable(this);
@@ -57,11 +67,12 @@ class Words {
 
   invalidateCaches() {
     this.#priorityCache.clear();
+    this.#masteryCache.clear();
   }
 
   setWords(words: WordData[]) {
     this.wordData = new Map(words.map((w) => [w.word, w]));
-    this.#priorityCache.clear();
+    this.invalidateCaches();
   }
 
   addWord(word: string, translation: string, id: string) {
@@ -80,10 +91,13 @@ class Words {
 
   deleteWord(word: string) {
     this.wordData.delete(word);
+    this.#priorityCache.delete(word);
+    this.#masteryCache.delete(word);
   }
 
   removeAllWords() {
     this.wordData.clear();
+    this.invalidateCaches();
   }
 
   // Record a correct attempt with input time
@@ -113,6 +127,7 @@ class Words {
 
     data.lastPracticedAt = now;
     this.#priorityCache.delete(word);
+    this.#masteryCache.delete(word);
   }
 
   // Record an incorrect attempt (hint revealed)
@@ -123,20 +138,30 @@ class Words {
     data.totalAttempts += 1;
     data.lastPracticedAt = new Date();
     this.#priorityCache.delete(word);
+    this.#masteryCache.delete(word);
+  }
+
+  #getMastery(word: string, data: WordData): MasteryResult {
+    let result = this.#masteryCache.get(word);
+    if (!result) {
+      result = calculateMasteryScore(data);
+      this.#masteryCache.set(word, result);
+    }
+    return result;
   }
 
   // Get mastery score for a word (0-100)
   getMasteryScore(word: string): number {
     const data = this.wordData.get(word);
     if (!data) return 0;
-    return calculateMasteryScore(data).score;
+    return this.#getMastery(word, data).score;
   }
 
   // Get detailed mastery result for a word
   getMasteryResult(word: string): MasteryResult | null {
     const data = this.wordData.get(word);
     if (!data) return null;
-    return calculateMasteryScore(data);
+    return this.#getMastery(word, data);
   }
 
   // Get mastery level index (0-4) for UI display
@@ -157,7 +182,7 @@ class Words {
   }
 
   // Get overall average input time across all words
-  getOverallAverageInputTime(): number | null {
+  get overallAverageInputTime(): number | null {
     const allTimes: number[] = [];
     this.wordData.forEach((data) => {
       allTimes.push(...data.inputTimes);
@@ -174,19 +199,18 @@ class Words {
     return 2;
   }
 
-  // Get average input time for words in the same length category
-  getAverageTimeByLengthCategory(category: number): number | null {
-    const categoryTimes: number[] = [];
+  // Get average input time for each word length category
+  get averageTimeByLengthCategory(): (number | null)[] {
+    const categoryTimes: number[][] = [[], [], []];
 
     this.wordData.forEach((data, word) => {
-      if (this.getWordLengthCategory(word) === category) {
-        categoryTimes.push(...data.inputTimes);
-      }
+      categoryTimes[this.getWordLengthCategory(word)].push(...data.inputTimes);
     });
 
-    if (categoryTimes.length === 0) return null;
-    return (
-      categoryTimes.reduce((sum, time) => sum + time, 0) / categoryTimes.length
+    return categoryTimes.map((times) =>
+      times.length === 0
+        ? null
+        : times.reduce((sum, time) => sum + time, 0) / times.length
     );
   }
 
@@ -233,14 +257,6 @@ class Words {
     );
   }
 
-  get allWords(): Map<string, string> {
-    const result = new Map<string, string>();
-    this.wordData.forEach((data, word) => {
-      result.set(word, data.translation);
-    });
-    return result;
-  }
-
   // Get random words weighted by practice priority
   getRandomWords(max: number = Words.MAX_RANDOM_WORDS): [string, string][] {
     const wordEntries = Array.from(this.wordData.entries());
@@ -252,7 +268,7 @@ class Words {
     const wordsWithPriority = wordEntries.map(([word, data]) => {
       let entry = this.#priorityCache.get(word);
       if (!entry) {
-        const masteryScore = calculateMasteryScore(data).score;
+        const masteryScore = this.#getMastery(word, data).score;
         const priority = calculatePriority(
           masteryScore,
           data.lastPracticedAt,
@@ -316,7 +332,7 @@ class Words {
         word,
         avgTime: avg,
         count: times.length,
-        masteryScore: calculateMasteryScore(data).score,
+        masteryScore: this.#getMastery(word, data).score,
         correctCount: data.correctCount,
         totalAttempts: data.totalAttempts,
       });
@@ -343,13 +359,30 @@ const commitBatchOperations = async (
 
 const words = new Words();
 
-export const useFirestoreWords = () => {
+interface WordsContextValue {
+  words: Words;
+  addWord: (word: string, translation: string) => Promise<void>;
+  deleteWord: (word: string) => Promise<void>;
+  updateTranslation: (word: string, translation: string) => Promise<void>;
+  removeAllWords: () => Promise<void>;
+  recordCorrectAttempt: (word: string, inputTimeSeconds: number) => void;
+  recordIncorrectAttempt: (word: string) => void;
+  syncToFirestore: () => Promise<void>;
+  resetPracticeRecords: () => Promise<void>;
+  loading: boolean;
+  error: string | null;
+  syncing: boolean;
+  pendingCount: number;
+}
+
+const WordsContext = createContext<WordsContextValue | null>(null);
+
+export const WordsProvider: FC<{ children: ReactNode }> = ({ children }) => {
   const { user } = useAuth();
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [syncing, setSyncing] = useState(false);
   const [pendingCount, setPendingCount] = useState(0);
-  const syncTimerRef = useRef<NodeJS.Timeout | null>(null);
 
   useEffect(() => {
     if (!user) {
@@ -390,25 +423,24 @@ export const useFirestoreWords = () => {
           // If Firestore data matches or exceeds queue data, remove from queue
           const queue = SyncQueueManager.getQueue();
           if (queue.length > 0) {
-            const staleIds: string[] = [];
+            const wordsById = new Map(wordsData.map((w) => [w.id, w]));
+            const staleIds = new Set<string>();
             queue.forEach((item) => {
-              const firestoreWord = wordsData.find((w) => w.id === item.wordId);
-              if (firestoreWord) {
-                // If Firestore has same or newer data, this queue item is stale
-                if (
-                  firestoreWord.totalAttempts >= item.data.totalAttempts &&
-                  firestoreWord.correctCount >= item.data.correctCount
-                ) {
-                  staleIds.push(item.id);
-                }
+              const firestoreWord = wordsById.get(item.wordId);
+              // If Firestore has same or newer data, this queue item is stale
+              if (
+                firestoreWord &&
+                firestoreWord.totalAttempts >= item.data.totalAttempts &&
+                firestoreWord.correctCount >= item.data.correctCount
+              ) {
+                staleIds.add(item.id);
               }
             });
 
-            if (staleIds.length > 0) {
-              const updatedQueue = queue.filter(
-                (item) => !staleIds.includes(item.id)
+            if (staleIds.size > 0) {
+              SyncQueueManager.saveQueue(
+                queue.filter((item) => !staleIds.has(item.id))
               );
-              SyncQueueManager.saveQueue(updatedQueue);
               setPendingCount(SyncQueueManager.getUniqueWordCount());
             }
           }
@@ -429,75 +461,84 @@ export const useFirestoreWords = () => {
     }
   }, [user]);
 
-  const addWord = async (word: string, translation: string) => {
-    if (!user) {
-      throw new Error(tError("error.notAuthenticated"));
-    }
+  const addWord = useCallback(
+    async (word: string, translation: string) => {
+      if (!user) {
+        throw new Error(tError("error.notAuthenticated"));
+      }
 
-    try {
-      const userId = getEffectiveUserId(user);
-      const wordsCollection = collection(db, "users", userId, "words");
+      try {
+        const userId = getEffectiveUserId(user);
+        const wordsCollection = collection(db, "users", userId, "words");
 
-      await addDoc(wordsCollection, {
-        word,
-        translation,
-        correctCount: 0,
-        totalAttempts: 0,
-        inputTimes: [],
-        lastPracticedAt: null,
-        correctPracticeDates: [],
-        createdAt: new Date(),
-      });
-    } catch (err) {
-      console.error("Failed to add word:", err);
-      throw new Error(`${tError("addWord.addFailed")}${err}`);
-    }
-  };
+        await addDoc(wordsCollection, {
+          word,
+          translation,
+          correctCount: 0,
+          totalAttempts: 0,
+          inputTimes: [],
+          lastPracticedAt: null,
+          correctPracticeDates: [],
+          createdAt: new Date(),
+        });
+      } catch (err) {
+        console.error("Failed to add word:", err);
+        throw new Error(`${tError("addWord.addFailed")}${err}`);
+      }
+    },
+    [user]
+  );
 
-  const deleteWord = async (word: string) => {
-    if (!user) {
-      throw new Error(tError("error.notAuthenticated"));
-    }
+  const deleteWord = useCallback(
+    async (word: string) => {
+      if (!user) {
+        throw new Error(tError("error.notAuthenticated"));
+      }
 
-    const wordId = words.getWordId(word);
-    if (!wordId) {
-      throw new Error(tError("error.wordNotFound"));
-    }
+      const wordId = words.getWordId(word);
+      if (!wordId) {
+        throw new Error(tError("error.wordNotFound"));
+      }
 
-    try {
-      const userId = getEffectiveUserId(user);
-      await deleteDoc(doc(db, "users", userId, "words", wordId));
-    } catch (err) {
-      console.error("Failed to delete word:", err);
-      throw new Error(tError("error.deleteWordFailed"));
-    }
-  };
+      try {
+        const userId = getEffectiveUserId(user);
+        await deleteDoc(doc(db, "users", userId, "words", wordId));
+      } catch (err) {
+        console.error("Failed to delete word:", err);
+        throw new Error(tError("error.deleteWordFailed"));
+      }
+    },
+    [user]
+  );
 
-  const updateTranslation = async (word: string, translation: string) => {
-    if (!user) {
-      throw new Error(tError("error.notAuthenticated"));
-    }
+  const updateTranslation = useCallback(
+    async (word: string, translation: string) => {
+      if (!user) {
+        throw new Error(tError("error.notAuthenticated"));
+      }
 
-    const wordId = words.getWordId(word);
-    if (!wordId) {
-      throw new Error(tError("error.wordNotFound"));
-    }
+      const wordId = words.getWordId(word);
+      if (!wordId) {
+        throw new Error(tError("error.wordNotFound"));
+      }
 
-    try {
-      const userId = getEffectiveUserId(user);
-      const wordDocRef = doc(db, "users", userId, "words", wordId);
-      await updateDoc(wordDocRef, {
-        translation,
-      });
+      try {
+        const userId = getEffectiveUserId(user);
+        const wordDocRef = doc(db, "users", userId, "words", wordId);
+        await updateDoc(wordDocRef, {
+          translation,
+        });
 
-      words.updateTranslation(word, translation);
-    } catch (err) {
-      console.error("Failed to update translation:", err);
-      throw new Error(tError("error.updateTranslationFailed"));
-    }
-  };
+        words.updateTranslation(word, translation);
+      } catch (err) {
+        console.error("Failed to update translation:", err);
+        throw new Error(tError("error.updateTranslationFailed"));
+      }
+    },
+    [user]
+  );
 
-  const removeAllWords = async () => {
+  const removeAllWords = useCallback(async () => {
     if (!user) {
       throw new Error(tError("error.notAuthenticated"));
     }
@@ -514,30 +555,33 @@ export const useFirestoreWords = () => {
       console.error("Failed to remove all words:", err);
       throw new Error(tError("error.removeWordsFailed"));
     }
-  };
+  }, [user]);
 
-  const recordCorrectAttempt = (word: string, inputTimeSeconds: number) => {
-    words.recordCorrectAttempt(word, inputTimeSeconds);
+  const recordCorrectAttempt = useCallback(
+    (word: string, inputTimeSeconds: number) => {
+      words.recordCorrectAttempt(word, inputTimeSeconds);
 
-    const wordId = words.getWordId(word);
-    const data = words.getWordData(word);
-    if (wordId && data) {
-      SyncQueueManager.addToQueue({
-        type: "attempt",
-        word,
-        wordId,
-        data: {
-          correctCount: data.correctCount,
-          totalAttempts: data.totalAttempts,
-          inputTimes: data.inputTimes,
-          correctPracticeDates: data.correctPracticeDates,
-        },
-      });
-      setPendingCount(SyncQueueManager.getUniqueWordCount());
-    }
-  };
+      const wordId = words.getWordId(word);
+      const data = words.getWordData(word);
+      if (wordId && data) {
+        SyncQueueManager.addToQueue({
+          type: "attempt",
+          word,
+          wordId,
+          data: {
+            correctCount: data.correctCount,
+            totalAttempts: data.totalAttempts,
+            inputTimes: data.inputTimes,
+            correctPracticeDates: data.correctPracticeDates,
+          },
+        });
+        setPendingCount(SyncQueueManager.getUniqueWordCount());
+      }
+    },
+    []
+  );
 
-  const recordIncorrectAttempt = (word: string) => {
+  const recordIncorrectAttempt = useCallback((word: string) => {
     words.recordIncorrectAttempt(word);
 
     const wordId = words.getWordId(word);
@@ -556,9 +600,9 @@ export const useFirestoreWords = () => {
       });
       setPendingCount(SyncQueueManager.getUniqueWordCount());
     }
-  };
+  }, []);
 
-  const syncToFirestore = async () => {
+  const syncToFirestore = useCallback(async () => {
     if (!user) {
       console.warn("User not authenticated, skipping sync");
       return;
@@ -638,32 +682,24 @@ export const useFirestoreWords = () => {
     } finally {
       setSyncing(false);
     }
-  };
+  }, [user]);
 
   useEffect(() => {
     if (!user) return;
 
-    const doSync = () => syncToFirestore();
-
     setPendingCount(SyncQueueManager.getUniqueWordCount());
 
     const SYNC_INTERVAL = 30 * 1000;
+    const timer = setInterval(() => syncToFirestore(), SYNC_INTERVAL);
 
-    syncTimerRef.current = setInterval(doSync, SYNC_INTERVAL);
+    syncToFirestore();
 
-    doSync();
-
-    return () => {
-      if (syncTimerRef.current) {
-        clearInterval(syncTimerRef.current);
-      }
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [user?.uid]);
+    return () => clearInterval(timer);
+  }, [user, syncToFirestore]);
 
   useEffect(() => {
     const handleVisibilityChange = () => {
-      if (document.visibilityState === "visible" && user) {
+      if (document.visibilityState === "visible") {
         syncToFirestore();
       }
     };
@@ -671,22 +707,18 @@ export const useFirestoreWords = () => {
     document.addEventListener("visibilitychange", handleVisibilityChange);
     return () =>
       document.removeEventListener("visibilitychange", handleVisibilityChange);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [user?.uid]);
+  }, [syncToFirestore]);
 
   useEffect(() => {
     const handleOnline = () => {
-      if (user) {
-        syncToFirestore();
-      }
+      syncToFirestore();
     };
 
     window.addEventListener("online", handleOnline);
     return () => window.removeEventListener("online", handleOnline);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [user?.uid]);
+  }, [syncToFirestore]);
 
-  const resetPracticeRecords = async () => {
+  const resetPracticeRecords = useCallback(async () => {
     if (!user) {
       throw new Error(tError("error.notAuthenticated"));
     }
@@ -722,21 +754,49 @@ export const useFirestoreWords = () => {
       console.error("Failed to reset practice records:", err);
       throw new Error(tError("error.resetFailed"));
     }
-  };
+  }, [user]);
 
-  return {
-    words,
-    addWord,
-    deleteWord,
-    updateTranslation,
-    removeAllWords,
-    recordCorrectAttempt,
-    recordIncorrectAttempt,
-    syncToFirestore,
-    resetPracticeRecords,
-    loading,
-    error,
-    syncing,
-    pendingCount,
-  };
+  const value = useMemo<WordsContextValue>(
+    () => ({
+      words,
+      addWord,
+      deleteWord,
+      updateTranslation,
+      removeAllWords,
+      recordCorrectAttempt,
+      recordIncorrectAttempt,
+      syncToFirestore,
+      resetPracticeRecords,
+      loading,
+      error,
+      syncing,
+      pendingCount,
+    }),
+    [
+      addWord,
+      deleteWord,
+      updateTranslation,
+      removeAllWords,
+      recordCorrectAttempt,
+      recordIncorrectAttempt,
+      syncToFirestore,
+      resetPracticeRecords,
+      loading,
+      error,
+      syncing,
+      pendingCount,
+    ]
+  );
+
+  return (
+    <WordsContext.Provider value={value}>{children}</WordsContext.Provider>
+  );
+};
+
+export const useFirestoreWords = (): WordsContextValue => {
+  const context = useContext(WordsContext);
+  if (!context) {
+    throw new Error("useFirestoreWords must be used within WordsProvider");
+  }
+  return context;
 };

--- a/scripts/sync-preview-words.mjs
+++ b/scripts/sync-preview-words.mjs
@@ -18,23 +18,48 @@ initializeApp({
 const db = getFirestore();
 
 const sourceCollection = db.collection("users").doc(prodUserId).collection("words");
-const targetDoc = db.collection("users").doc(PREVIEW_USER_ID);
-const targetCollection = targetDoc.collection("words");
+const targetCollection = db.collection("users").doc(PREVIEW_USER_ID).collection("words");
 
-const snapshot = await sourceCollection.get();
-console.log(`Fetched ${snapshot.size} words from users/${prodUserId}/words`);
+const [sourceSnapshot, targetSnapshot] = await Promise.all([
+  sourceCollection.get(),
+  targetCollection.get(),
+]);
+console.log(`Fetched ${sourceSnapshot.size} prod words, ${targetSnapshot.size} preview words`);
 
-await db.recursiveDelete(targetDoc);
-console.log(`Cleared users/${PREVIEW_USER_ID}`);
+const sourceData = new Map(sourceSnapshot.docs.map((doc) => [doc.id, doc.data()]));
+const targetData = new Map(targetSnapshot.docs.map((doc) => [doc.id, doc.data()]));
+
+const toWrite = [];
+const toDelete = [];
+
+for (const [id, data] of sourceData) {
+  const existing = targetData.get(id);
+  if (!existing || JSON.stringify(existing) !== JSON.stringify(data)) {
+    toWrite.push([id, data]);
+  }
+}
+
+for (const id of targetData.keys()) {
+  if (!sourceData.has(id)) {
+    toDelete.push(id);
+  }
+}
+
+console.log(`Diff: ${toWrite.length} to write, ${toDelete.length} to delete`);
 
 const BATCH_SIZE = 500;
-for (let i = 0; i < snapshot.docs.length; i += BATCH_SIZE) {
+const operations = [
+  ...toWrite.map(([id, data]) => (batch) => batch.set(targetCollection.doc(id), data)),
+  ...toDelete.map((id) => (batch) => batch.delete(targetCollection.doc(id))),
+];
+
+for (let i = 0; i < operations.length; i += BATCH_SIZE) {
   const batch = db.batch();
-  for (const doc of snapshot.docs.slice(i, i + BATCH_SIZE)) {
-    batch.set(targetCollection.doc(doc.id), doc.data());
+  for (const apply of operations.slice(i, i + BATCH_SIZE)) {
+    apply(batch);
   }
   await batch.commit();
-  console.log(`Synced ${Math.min(i + BATCH_SIZE, snapshot.size)}/${snapshot.size} words`);
+  console.log(`Committed ${Math.min(i + BATCH_SIZE, operations.length)}/${operations.length} operations`);
 }
 
 console.log("Sync completed");


### PR DESCRIPTION
## 变更内容

### Firestore 成本
- **sync-preview-words 改 diff 增量同步**：不再全删全写，只写新增/变更、只删已移除的文档；cron 从每 30 分钟降为每 6 小时。词库较大时每天可省数万次写操作

### 前端性能
- **mastery 计算缓存**：新增 `#masteryCache`，`getMasteryScore` / `practiceStats` / `getRandomWords` 统一复用，随 attempt 与快照自动失效（之前练习页每次击键都重算当前单词熟练度）
- **computed getter**：`overallAverageInputTime` / `averageTimeByLengthCategory` 改为 MobX computed，profile 页不再每次渲染全量遍历；删除每次访问都重建 Map 的 `allWords` getter
- **全局单次订阅**：`onSnapshot` 提升到 `WordsProvider`（根 layout），页面切换不再退订/重订全集合；快照回调的队列清理从 O(queue × words) 优化为 O(queue + words)
- **练习页渲染**：拆出 observer 行组件 `WordRow`，击键只重渲染当前行；`parseTranslation` 移到模块级；回调全部稳定化；顺带消除 3 处 `eslint-disable exhaustive-deps`

## 验证
- `bun run lint` ✅
- `bun run build` ✅