### PR TITLE
feat(api): API 路由限流与批改接口本地判等前置

### DIFF
--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -11,8 +11,10 @@
 ## 造句练习与 DeepSeek 集成
 
 - 造句/批改功能通过服务端 Route Handler（`src/app/api/sentence/*`）代理调用 DeepSeek，浏览器只请求本站 `/api/*`。
-- `/api/sentence/*` 要求请求头携带 Firebase ID token（`Authorization: Bearer <token>`），由 `src/lib/serverAuth.ts` 通过 Identity Toolkit REST API 校验，未通过返回 401。
+- `/api/*` 要求请求头携带 Firebase ID token（`Authorization: Bearer <token>`），由 `src/lib/serverAuth.ts` 通过 Identity Toolkit REST API 校验；校验通过返回 `{ uid }`，失败返回 401 的 NextResponse（用 `instanceof NextResponse` 区分）。
+- `/api/*` 按 uid 做进程内固定窗口限流（`src/lib/rateLimit.ts`），超限返回 429；新增 API 路由时应加上限流与输入长度上限。
 - DeepSeek 封装位于 `src/lib/deepseek.ts`，读取环境变量 `DEEPSEEK_API_KEY`、`DEEPSEEK_BASE_URL`、`DEEPSEEK_MODEL`。
 - API Key 只允许在服务端使用，禁止加 `NEXT_PUBLIC_` 前缀或下发到前端。
 - 造句练习复用 `useFirestoreWords` 的单词库与 `recordCorrectAttempt`/`recordIncorrectAttempt`，练习结果计入单词熟练度并同步到 Firebase。
 - 造句题目界面不直接显示目标单词（答题后的反馈区才显示），这是有意设计：学生凭中文句子推断用词，因此造句请求会把词库中存的中文译法随目标词一并传给模型，prompt 要求中文译文自然地道、使用参考译法且能让学生反推出目标词；批改时对目标词的同义表达不判错、仅提示。
+- 批改接口在调用模型前先对答案与参考译文做规范化判等，完全一致直接返回满分，不消耗模型调用。

--- a/apps/web/src/app/api/sentence/check/route.ts
+++ b/apps/web/src/app/api/sentence/check/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { chatCompletionJson, DeepSeekError } from "@/lib/deepseek";
 import { verifyFirebaseIdToken } from "@/lib/serverAuth";
+import { checkRateLimit } from "@/lib/rateLimit";
 
 interface CheckRequest {
   chinese?: string;
@@ -24,9 +25,22 @@ const normalizeForComparison = (value: string) =>
     .replace(/\s+/g, " ")
     .trim();
 
+const RATE_LIMIT_PER_MINUTE = 20;
+const RATE_LIMIT_WINDOW_MS = 60 * 1000;
+const MAX_SENTENCE_LENGTH = 500;
+const MAX_WORDS = 5;
+const MAX_WORD_LENGTH = 50;
+
 export async function POST(request: Request) {
-  const authError = await verifyFirebaseIdToken(request);
-  if (authError) return authError;
+  const auth = await verifyFirebaseIdToken(request);
+  if (auth instanceof NextResponse) return auth;
+
+  const rateLimitError = checkRateLimit(
+    `${auth.uid}:sentence/check`,
+    RATE_LIMIT_PER_MINUTE,
+    RATE_LIMIT_WINDOW_MS
+  );
+  if (rateLimitError) return rateLimitError;
 
   let body: CheckRequest;
   try {
@@ -43,10 +57,35 @@ export async function POST(request: Request) {
         .filter((word): word is string => typeof word === "string")
         .map((word) => word.trim())
         .filter(Boolean)
+        .slice(0, MAX_WORDS)
     : [];
 
   if (!chinese || !userAnswer) {
     return NextResponse.json({ error: "缺少题目或答案" }, { status: 400 });
+  }
+
+  if (
+    chinese.length > MAX_SENTENCE_LENGTH ||
+    userAnswer.length > MAX_SENTENCE_LENGTH ||
+    reference.length > MAX_SENTENCE_LENGTH ||
+    words.some((word) => word.length > MAX_WORD_LENGTH)
+  ) {
+    return NextResponse.json({ error: "输入内容过长" }, { status: 400 });
+  }
+
+  const exactMatch =
+    reference.length > 0 &&
+    normalizeForComparison(userAnswer).length > 0 &&
+    normalizeForComparison(userAnswer) === normalizeForComparison(reference);
+
+  if (exactMatch) {
+    return NextResponse.json({
+      correct: true,
+      score: 100,
+      feedback: "答案正确，评分已按大小写不敏感处理。",
+      corrected: reference,
+      issues: [],
+    });
   }
 
   try {
@@ -67,21 +106,6 @@ export async function POST(request: Request) {
         content: `中文句子：${chinese}\n目标单词：${words.join(", ")}\n参考译文：${reference}\n学生译文：${userAnswer}`,
       },
     ]);
-
-    const caseInsensitiveMatch =
-      reference.length > 0 &&
-      normalizeForComparison(userAnswer).length > 0 &&
-      normalizeForComparison(userAnswer) === normalizeForComparison(reference);
-
-    if (caseInsensitiveMatch) {
-      return NextResponse.json({
-        correct: true,
-        score: 100,
-        feedback: "答案正确，评分已按大小写不敏感处理。",
-        corrected: reference,
-        issues: [],
-      });
-    }
 
     return NextResponse.json({
       correct: Boolean(result.correct),

--- a/apps/web/src/app/api/sentence/generate/route.ts
+++ b/apps/web/src/app/api/sentence/generate/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { chatCompletionJson, DeepSeekError } from "@/lib/deepseek";
 import { verifyFirebaseIdToken } from "@/lib/serverAuth";
+import { checkRateLimit } from "@/lib/rateLimit";
 
 interface GenerateRequest {
   words?: Array<{ word?: string; translation?: string }>;
@@ -14,10 +15,21 @@ interface GenerateResult {
 
 const MAX_WORDS = 3;
 const MIN_WORDS = 1;
+const MAX_WORD_LENGTH = 50;
+const MAX_TRANSLATION_LENGTH = 200;
+const RATE_LIMIT_PER_MINUTE = 10;
+const RATE_LIMIT_WINDOW_MS = 60 * 1000;
 
 export async function POST(request: Request) {
-  const authError = await verifyFirebaseIdToken(request);
-  if (authError) return authError;
+  const auth = await verifyFirebaseIdToken(request);
+  if (auth instanceof NextResponse) return auth;
+
+  const rateLimitError = checkRateLimit(
+    `${auth.uid}:sentence/generate`,
+    RATE_LIMIT_PER_MINUTE,
+    RATE_LIMIT_WINDOW_MS
+  );
+  if (rateLimitError) return rateLimitError;
 
   let body: GenerateRequest;
   try {
@@ -38,6 +50,16 @@ export async function POST(request: Request) {
 
   if (words.length < MIN_WORDS) {
     return NextResponse.json({ error: "缺少单词" }, { status: 400 });
+  }
+
+  if (
+    words.some(
+      (item) =>
+        item.word.length > MAX_WORD_LENGTH ||
+        item.translation.length > MAX_TRANSLATION_LENGTH
+    )
+  ) {
+    return NextResponse.json({ error: "输入内容过长" }, { status: 400 });
   }
 
   try {

--- a/apps/web/src/app/api/translate/route.ts
+++ b/apps/web/src/app/api/translate/route.ts
@@ -1,8 +1,12 @@
 import { NextResponse } from "next/server";
 import { verifyFirebaseIdToken } from "@/lib/serverAuth";
+import { checkRateLimit } from "@/lib/rateLimit";
 import { FALLBACK_DICTIONARY } from "@/lib/dictionary";
 
 const WORD_PATTERN = /^[a-z]+$/;
+const MAX_WORD_LENGTH = 50;
+const RATE_LIMIT_PER_MINUTE = 30;
+const RATE_LIMIT_WINDOW_MS = 60 * 1000;
 
 async function translateToChinese(word: string): Promise<string | null> {
   let translation: string | null = null;
@@ -45,8 +49,15 @@ async function getEnglishDefinition(word: string): Promise<string | null> {
 }
 
 export async function POST(request: Request) {
-  const authError = await verifyFirebaseIdToken(request);
-  if (authError) return authError;
+  const auth = await verifyFirebaseIdToken(request);
+  if (auth instanceof NextResponse) return auth;
+
+  const rateLimitError = checkRateLimit(
+    `${auth.uid}:translate`,
+    RATE_LIMIT_PER_MINUTE,
+    RATE_LIMIT_WINDOW_MS
+  );
+  if (rateLimitError) return rateLimitError;
 
   let body: { word?: string };
   try {
@@ -58,7 +69,7 @@ export async function POST(request: Request) {
   const word =
     typeof body.word === "string" ? body.word.trim().toLowerCase() : "";
 
-  if (!WORD_PATTERN.test(word)) {
+  if (!WORD_PATTERN.test(word) || word.length > MAX_WORD_LENGTH) {
     return NextResponse.json({ error: "无效单词" }, { status: 400 });
   }
 

--- a/apps/web/src/lib/rateLimit.ts
+++ b/apps/web/src/lib/rateLimit.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+
+interface Bucket {
+  count: number;
+  resetAt: number;
+}
+
+const MAX_BUCKETS = 5000;
+const buckets = new Map<string, Bucket>();
+
+function evictExpiredBuckets(now: number) {
+  for (const [key, bucket] of buckets) {
+    if (bucket.resetAt <= now) buckets.delete(key);
+  }
+}
+
+export function checkRateLimit(
+  key: string,
+  limit: number,
+  windowMs: number
+): NextResponse | null {
+  const now = Date.now();
+  const bucket = buckets.get(key);
+
+  if (!bucket || bucket.resetAt <= now) {
+    if (buckets.size >= MAX_BUCKETS) evictExpiredBuckets(now);
+    buckets.set(key, { count: 1, resetAt: now + windowMs });
+    return null;
+  }
+
+  bucket.count += 1;
+  if (bucket.count > limit) {
+    return NextResponse.json(
+      { error: "请求过于频繁，请稍后再试" },
+      { status: 429 }
+    );
+  }
+  return null;
+}

--- a/apps/web/src/lib/serverAuth.ts
+++ b/apps/web/src/lib/serverAuth.ts
@@ -7,19 +7,27 @@ const DEFAULT_TOKEN_TTL_MS = 60 * 60 * 1000;
 const CACHE_SKEW_MS = 60 * 1000;
 const tokenCache = new Map<string, number>();
 
-function decodeTokenExpiry(token: string): number | null {
+function decodeTokenPayload(token: string): Record<string, unknown> | null {
   try {
     const parts = token.split(".");
     if (parts.length !== 3) return null;
-    const payload = JSON.parse(
+    return JSON.parse(
       Buffer.from(parts[1], "base64url").toString("utf8")
     );
-    const exp = payload.exp;
-    if (typeof exp !== "number" || !Number.isFinite(exp)) return null;
-    return exp * 1000;
   } catch {
     return null;
   }
+}
+
+function decodeTokenExpiry(token: string): number | null {
+  const exp = decodeTokenPayload(token)?.exp;
+  if (typeof exp !== "number" || !Number.isFinite(exp)) return null;
+  return exp * 1000;
+}
+
+function decodeTokenUid(token: string): string | null {
+  const uid = decodeTokenPayload(token)?.user_id;
+  return typeof uid === "string" && uid ? uid : null;
 }
 
 function evictExpiredTokens() {
@@ -31,7 +39,7 @@ function evictExpiredTokens() {
 
 export async function verifyFirebaseIdToken(
   request: Request
-): Promise<NextResponse | null> {
+): Promise<{ uid: string } | NextResponse> {
   const authorization = request.headers.get("authorization");
   const idToken = authorization?.startsWith("Bearer ")
     ? authorization.slice("Bearer ".length)
@@ -43,7 +51,9 @@ export async function verifyFirebaseIdToken(
 
   const cachedExpiry = tokenCache.get(idToken);
   if (cachedExpiry && cachedExpiry > Date.now()) {
-    return null;
+    const uid = decodeTokenUid(idToken);
+    if (uid) return { uid };
+    return NextResponse.json({ error: "登录状态无效" }, { status: 401 });
   }
 
   const apiKey = process.env.NEXT_PUBLIC_FIREBASE_API_KEY;
@@ -62,6 +72,14 @@ export async function verifyFirebaseIdToken(
       return NextResponse.json({ error: "登录状态无效" }, { status: 401 });
     }
 
+    const payload = (await response.json()) as {
+      users?: Array<{ localId?: string }>;
+    };
+    const uid = payload.users?.[0]?.localId ?? decodeTokenUid(idToken);
+    if (!uid) {
+      return NextResponse.json({ error: "登录状态无效" }, { status: 401 });
+    }
+
     const expiry =
       decodeTokenExpiry(idToken) ?? Date.now() + DEFAULT_TOKEN_TTL_MS;
     const ttl = expiry - Date.now() - CACHE_SKEW_MS;
@@ -70,7 +88,7 @@ export async function verifyFirebaseIdToken(
       tokenCache.set(idToken, Date.now() + ttl);
     }
 
-    return null;
+    return { uid };
   } catch {
     return NextResponse.json({ error: "身份验证失败" }, { status: 401 });
   }


### PR DESCRIPTION
## 变更内容

### 安全与成本
- **新增限流**：`src/lib/rateLimit.ts` 进程内固定窗口限流器，按 `uid:route` 计数，超限返回 429。此前三个 API 路由只验证登录，preview 环境匿名即可拿 token，DeepSeek 余额存在被刷风险
- **输入长度上限**：generate（word ≤ 50 / translation ≤ 200 / 最多 3 词）、check（句子 ≤ 500 / 最多 5 词）、translate（word ≤ 50），防止超长输入放大 token 消耗

### 性能
- **批改接口本地判等前置**：`/api/sentence/check` 先对答案与参考译文做规范化判等，完全一致直接返回 100 分，不再消耗一次 LLM 调用和 10s+ 延迟

### 配套调整
- `verifyFirebaseIdToken` 校验通过后返回 `{ uid }`（缓存命中从 JWT payload 解码，新验证用 `accounts:lookup` 的 `localId`），供限流按键使用

### 限额配置
| 路由 | 限额 |
|---|---|
| `/api/sentence/generate` | 10 次/分钟 |
| `/api/sentence/check` | 20 次/分钟 |
| `/api/translate` | 30 次/分钟 |

### 已知局限
限流与 token 缓存同为进程内实现，serverless 多实例下限额为每实例近似值，作为防刷第一道防线足够；如需精确全局限流可后续换 Vercel KV。

## 验证
- `bun run lint` ✅
- `bun run build` ✅