### PR TITLE
chore(infra): Terraform 防误删保护与 CI 增强

### DIFF
--- a/.github/workflows/infra-plan.yml
+++ b/.github/workflows/infra-plan.yml
@@ -11,9 +11,11 @@ on:
 jobs:
   plan:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
       id-token: write
+      pull-requests: write
     defaults:
       run:
         working-directory: infra
@@ -46,4 +48,41 @@ jobs:
         run: terraform validate
 
       - name: Terraform Plan
-        run: terraform plan -input=false -lock=false
+        id: plan
+        run: terraform plan -input=false -lock=false -no-color -out=plan.out 2>&1 | tee plan.txt
+
+      - name: Comment Plan
+        if: always()
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs');
+            const plan = fs.readFileSync('infra/plan.txt', 'utf8');
+            const marker = '<!-- terraform-plan-comment -->';
+            const truncated = plan.length > 60000 ? plan.slice(-60000) : plan;
+            const succeeded = ${{ steps.plan.outcome == 'success' }};
+            const body = `${marker}\n### Terraform Plan ${succeeded ? '✅' : '❌'}\n<details><summary>Show Plan</summary>\n\n\`\`\`\n${truncated}\n\`\`\`\n</details>`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find((comment) => comment.body?.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+            if (!succeeded) core.setFailed('Terraform plan failed');

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -23,6 +23,10 @@ on:
 jobs:
   lint-build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    concurrency:
+      group: web-${{ github.ref }}
+      cancel-in-progress: true
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -37,6 +41,10 @@ jobs:
 
       - name: Lint
         run: bun run lint
+        working-directory: apps/web
+
+      - name: Typecheck
+        run: bun x tsc --noEmit
         working-directory: apps/web
 
       - name: Build

--- a/infra/modules/firebase/firestore.tf
+++ b/infra/modules/firebase/firestore.tf
@@ -1,9 +1,15 @@
 resource "google_firestore_database" "this" {
-  provider    = google-beta
-  project     = google_project.this.project_id
-  name        = var.firestore_database_name
-  location_id = var.region
-  type        = var.firestore_type
+  provider                          = google-beta
+  project                           = google_project.this.project_id
+  name                              = var.firestore_database_name
+  location_id                       = var.region
+  type                              = var.firestore_type
+  point_in_time_recovery_enablement = "POINT_IN_TIME_RECOVERY_ENABLED"
+  delete_protection_state           = "DELETE_PROTECTION_ENABLED"
 
   depends_on = [google_project_service.firestore]
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }

--- a/infra/modules/firebase/main.tf
+++ b/infra/modules/firebase/main.tf
@@ -1,6 +1,10 @@
 resource "google_project" "this" {
   project_id = var.project_id
   name       = var.project_name
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "google_project_service" "firebase" {


### PR DESCRIPTION
## 变更内容

### Terraform 保护
- `google_project` 加 `prevent_destroy`，防止误删整个 GCP 项目
- `google_firestore_database`：
  - 启用 PITR（`POINT_IN_TIME_RECOVERY_ENABLED`，可恢复到 7 天内任意时间点）
  - 启用删除保护（`DELETE_PROTECTION_ENABLED`）
  - 加 `prevent_destroy`

> ⚠️ 合并后 `infra-deploy` 会自动 apply，Firestore 数据库将就地更新启用 PITR 与删除保护（无需重建、无停机），请留意 deploy 结果。

### CI 改进
- `web.yml`：`timeout-minutes: 15`、concurrency（同分支新 push 取消旧 run）、新增独立 `Typecheck` 步骤（先于 build 失败，反馈更快）
- `infra-plan.yml`：plan 结果回贴 PR comment（状态图标 + 折叠展示 + 超长截断，重复运行更新原评论），plan 失败时 job 失败

## 验证
- `terraform fmt -check -recursive` ✅
- `terraform validate` ✅
- `bun x tsc --noEmit`（typecheck 步骤）本地 ✅
- workflow YAML 语法校验 ✅