### PR TITLE
perf(web): 词库同步防重入、translate 超时缓存、增量合并与单元测试

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -47,6 +47,10 @@ jobs:
         run: bun x tsc --noEmit
         working-directory: apps/web
 
+      - name: Test
+        run: bun run test
+        working-directory: apps/web
+
       - name: Build
         run: bun run build
         working-directory: apps/web

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@
 ## 工具链
 
 - 本项目使用 bun（turbo monorepo，根目录有 `bun.lock`）。本机环境没有 node/npm/npx，运行脚本、安装依赖、执行测试一律用 `bun` / `bun x <命令>`。
+- 单元测试：`apps/web` 使用 vitest，在 `apps/web` 下运行 `bun run test`（即 `vitest run`），测试文件与源码同目录（`*.test.ts`）。
 
 ## 预览环境与 sync-preview-words
 

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -11,3 +11,6 @@ NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID=
 DEEPSEEK_API_KEY=
 DEEPSEEK_BASE_URL=https://api.deepseek.com
 DEEPSEEK_MODEL=deepseek-v4-flash
+
+# sync-preview-words 脚本使用：生产用户 UID（仅本地/CI 运行脚本时需要）
+PROD_USER_UID=

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -5,7 +5,9 @@
 ## 词库状态管理
 
 - `src/hooks/useFirestoreWords.tsx`：`Words` 是模块级 MobX 单例 store；`WordsProvider`（挂在根 layout）在登录后全局只做一次 `onSnapshot` 订阅，`useFirestoreWords` 只是读 Context，不要在页面里再订阅 Firestore。
-- 熟练度结果通过 `#masteryCache` 缓存（随 `recordCorrect/IncorrectAttempt`、`setWords` 失效），全量统计用 computed getter（`overallAverageInputTime`、`averageTimeByLengthCategory`、`practiceStats`），新增派生数据时优先用 computed getter 而非每次渲染重算。
+- 熟练度结果通过 `#masteryCache` 缓存（随 `recordCorrect/IncorrectAttempt`、`setWordData`/`deleteWord`/`removeAllWords` 失效），全量统计用 computed getter（`overallAverageInputTime`、`averageTimeByLengthCategory`、`practiceStats`），新增派生数据时优先用 computed getter 而非每次渲染重算。
+- Firestore `onSnapshot` 结果通过 `mergeSnapshotIntoStore` 增量合并到 store（仅更新变化的单词、按需使缓存失效），不要改成全量替换 `wordData`，否则会导致所有 observer 组件无谓重渲染。
+- `correctPracticeDates` 存 `YYYY-MM-DD` 本地日期字符串（`formatLocalPracticeDate`），不要存 ISO 时间戳，避免时区解析偏移；`getLocalPracticeDate` 对纯日期字符串短路返回。
 - 练习页的输入值在 `words.userInputs` 中，单词行是独立的 observer 组件（`WordRow`），只有对应行会随击键重渲染，不要在父组件渲染路径里读 `userInputs`。
 
 ## 造句练习与 DeepSeek 集成
@@ -17,4 +19,5 @@
 - API Key 只允许在服务端使用，禁止加 `NEXT_PUBLIC_` 前缀或下发到前端。
 - 造句练习复用 `useFirestoreWords` 的单词库与 `recordCorrectAttempt`/`recordIncorrectAttempt`，练习结果计入单词熟练度并同步到 Firebase。
 - 造句题目界面不直接显示目标单词（答题后的反馈区才显示），这是有意设计：学生凭中文句子推断用词，因此造句请求会把词库中存的中文译法随目标词一并传给模型，prompt 要求中文译文自然地道、使用参考译法且能让学生反推出目标词；批改时对目标词的同义表达不判错、仅提示。
-- 批改接口在调用模型前先对答案与参考译文做规范化判等，完全一致直接返回满分，不消耗模型调用。
+- 批改接口在调用模型前先对答案与参考译文做规范化判等（`src/lib/sentenceCompare.ts` 的 `normalizeForComparison`），完全一致直接返回满分，不消耗模型调用。
+- 纯函数测试用 vitest（`bun run test`，配置在 `vitest.config.mts`），核心算法（熟练度、翻译解析、句意判等、日期处理）新增改动时应同步补测试。

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",
-    "lint:fix": "eslint . --fix"
+    "lint:fix": "eslint . --fix",
+    "test": "vitest run"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.15",
@@ -34,7 +35,8 @@
     "eslint": "^9.39.3",
     "eslint-config-next": "^16.0.1",
     "typescript": "^5.9.3",
-    "vercel": "^58.0.0"
+    "vercel": "^58.0.0",
+    "vitest": "^4.1.10"
   },
   "repository": {
     "type": "git",

--- a/apps/web/src/app/api/sentence/check/route.ts
+++ b/apps/web/src/app/api/sentence/check/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { chatCompletionJson, DeepSeekError } from "@/lib/deepseek";
 import { verifyFirebaseIdToken } from "@/lib/serverAuth";
 import { checkRateLimit } from "@/lib/rateLimit";
+import { normalizeForComparison } from "@/lib/sentenceCompare";
 
 interface CheckRequest {
   chinese?: string;
@@ -17,13 +18,6 @@ interface CheckResult {
   corrected: string;
   issues: string[];
 }
-
-const normalizeForComparison = (value: string) =>
-  value
-    .toLowerCase()
-    .replace(/[^\p{L}\p{N}\s]/gu, " ")
-    .replace(/\s+/g, " ")
-    .trim();
 
 const RATE_LIMIT_PER_MINUTE = 20;
 const RATE_LIMIT_WINDOW_MS = 60 * 1000;

--- a/apps/web/src/app/api/translate/route.ts
+++ b/apps/web/src/app/api/translate/route.ts
@@ -7,35 +7,54 @@ const WORD_PATTERN = /^[a-z]+$/;
 const MAX_WORD_LENGTH = 50;
 const RATE_LIMIT_PER_MINUTE = 30;
 const RATE_LIMIT_WINDOW_MS = 60 * 1000;
+const FETCH_TIMEOUT_MS = 8000;
+const MAX_CACHE_ENTRIES = 1000;
+
+interface TranslationCacheEntry {
+  chineseTranslation: string | null;
+  englishDefinition: string | null;
+}
+
+const translationCache = new Map<string, TranslationCacheEntry>();
+
+async function fetchWithTimeout(url: string): Promise<Response | null> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    return await fetch(url, { signal: controller.signal });
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
 
 async function translateToChinese(word: string): Promise<string | null> {
-  let translation: string | null = null;
-  try {
-    const response = await fetch(
-      `https://translate.googleapis.com/translate_a/single?client=gtx&sl=en&tl=zh-CN&dt=t&q=${encodeURIComponent(word)}`
-    );
-    if (response.ok) {
+  const response = await fetchWithTimeout(
+    `https://translate.googleapis.com/translate_a/single?client=gtx&sl=en&tl=zh-CN&dt=t&q=${encodeURIComponent(word)}`
+  );
+  if (response?.ok) {
+    try {
       const data = await response.json();
-      translation = data?.[0]?.[0]?.[0] ?? null;
+      const translation = data?.[0]?.[0]?.[0] ?? null;
+      if (translation && translation !== word) {
+        return translation;
+      }
+    } catch {
+      // fall through to dictionary
     }
-  } catch {
-    translation = null;
-  }
-
-  if (translation && translation !== word) {
-    return translation;
   }
   return FALLBACK_DICTIONARY[word] ?? null;
 }
 
 async function getEnglishDefinition(word: string): Promise<string | null> {
+  const response = await fetchWithTimeout(
+    `https://api.datamuse.com/words?sp=${encodeURIComponent(word)}&md=d&max=10`
+  );
+  if (!response?.ok) {
+    return null;
+  }
   try {
-    const response = await fetch(
-      `https://api.datamuse.com/words?sp=${encodeURIComponent(word)}&md=d&max=10`
-    );
-    if (!response.ok) {
-      return null;
-    }
     const data: Array<{ word?: string; defs?: string[] }> =
       await response.json();
     const exactMatch = data.find((item) => item.word?.toLowerCase() === word);
@@ -73,10 +92,21 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "无效单词" }, { status: 400 });
   }
 
+  const cached = translationCache.get(word);
+  if (cached) {
+    return NextResponse.json(cached);
+  }
+
   const [chineseTranslation, englishDefinition] = await Promise.all([
     translateToChinese(word),
     getEnglishDefinition(word),
   ]);
 
-  return NextResponse.json({ chineseTranslation, englishDefinition });
+  const result: TranslationCacheEntry = { chineseTranslation, englishDefinition };
+  if (translationCache.size >= MAX_CACHE_ENTRIES) {
+    translationCache.clear();
+  }
+  translationCache.set(word, result);
+
+  return NextResponse.json(result);
 }

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -4,14 +4,8 @@ import { Button, ConfirmDialog, Input, MasteryBar } from "@/components/ui";
 import { useFirestoreWords, useLocale, toast, useAuth } from "@/hooks";
 import { observer } from "mobx-react-lite";
 import Link from "next/link";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { type Locale } from "@/lib/i18n";
-
-const getWordLengthCategory = (word: string): number => {
-  if (word.length <= 5) return 0;
-  if (word.length <= 10) return 1;
-  return 2;
-};
 
 const COLOR_CLASSES = {
   blue: {
@@ -46,19 +40,20 @@ const Profile = observer(() => {
 
   const wordsWithStats = words.practiceStats;
 
-  const wordsByCategory: Record<number, typeof wordsWithStats> = {
-    0: [], // short words
-    1: [], // medium words
-    2: [], // long words
-  };
-
-  wordsWithStats.forEach((item) => {
-    const category = getWordLengthCategory(item.word);
-    wordsByCategory[category].push(item);
-  });
+  const wordsByCategory = useMemo<Record<number, typeof wordsWithStats>>(() => {
+    const grouped: Record<number, typeof wordsWithStats> = {
+      0: [], // short words
+      1: [], // medium words
+      2: [], // long words
+    };
+    wordsWithStats.forEach((item) => {
+      grouped[words.getWordLengthCategory(item.word)].push(item);
+    });
+    return grouped;
+  }, [wordsWithStats, words]);
 
   // Filter words by search query
-  const getFilteredWordsByCategory = () => {
+  const filteredWordsByCategory = useMemo<Record<number, typeof wordsWithStats>>(() => {
     if (!searchQuery.trim()) {
       return wordsByCategory;
     }
@@ -74,9 +69,7 @@ const Profile = observer(() => {
       );
     });
     return filtered;
-  };
-
-  const filteredWordsByCategory = getFilteredWordsByCategory();
+  }, [searchQuery, wordsByCategory]);
 
   // Calculate average mastery score
   const avgMasteryScore = wordsWithStats.length > 0

--- a/apps/web/src/app/words/page.tsx
+++ b/apps/web/src/app/words/page.tsx
@@ -5,30 +5,9 @@ import { useCallback, useEffect, useState, useRef, type FormEvent, type RefObjec
 import { observer } from "mobx-react-lite";
 import Link from "next/link";
 import { useFirestoreWords, useLocale, toast } from "@/hooks";
+import { parseTranslation } from "@/lib/parseTranslation";
 import type { Words } from "@/hooks/useFirestoreWords";
 import type { TranslationKey } from "@/lib/i18n";
-
-const parseTranslation = (translation: string) => {
-  const segments = translation
-    .split("\n")
-    .map((segment) => segment.trim())
-    .filter(Boolean);
-
-  if (segments.length === 0) {
-    return { englishDefinition: "", chineseTranslation: "" };
-  }
-
-  if (segments.length === 1) {
-    const single = segments[0];
-    const hasChinese = /[\u4e00-\u9fff]/.test(single);
-    return hasChinese ? { englishDefinition: "", chineseTranslation: single } : { englishDefinition: single, chineseTranslation: "" };
-  }
-
-  return {
-    englishDefinition: segments[0],
-    chineseTranslation: segments.slice(1).join("\n"),
-  };
-};
 
 interface WordRowProps {
   word: string;

--- a/apps/web/src/hooks/useFirestoreWords.tsx
+++ b/apps/web/src/hooks/useFirestoreWords.tsx
@@ -6,6 +6,7 @@ import {
   useCallback,
   useMemo,
   useContext,
+  useRef,
   createContext,
   type FC,
   type ReactNode,
@@ -20,6 +21,7 @@ import {
   updateDoc,
   writeBatch,
   type WriteBatch,
+  type DocumentData,
 } from "firebase/firestore";
 import { db, getEffectiveUserId } from "@/lib/firebase";
 import { useAuth } from "@/hooks/useAuth";
@@ -70,9 +72,11 @@ export class Words {
     this.#masteryCache.clear();
   }
 
-  setWords(words: WordData[]) {
-    this.wordData = new Map(words.map((w) => [w.word, w]));
-    this.invalidateCaches();
+  // 增量更新单个单词的数据（新增或替换），只使该词的缓存失效
+  setWordData(word: string, data: WordData) {
+    this.wordData.set(word, data);
+    this.#priorityCache.delete(word);
+    this.#masteryCache.delete(word);
   }
 
   addWord(word: string, translation: string, id: string) {
@@ -110,12 +114,8 @@ export class Words {
     data.inputTimes.push(inputTimeSeconds);
     const now = new Date();
     const today = formatLocalPracticeDate(now);
-    if (
-      !data.correctPracticeDates.some(
-        (practiceDate) => getLocalPracticeDate(practiceDate) === today
-      )
-    ) {
-      data.correctPracticeDates.push(now.toISOString());
+    if (!data.correctPracticeDates.includes(today)) {
+      data.correctPracticeDates.push(today);
       if (data.correctPracticeDates.length > Words.MAX_CORRECT_PRACTICE_DATES) {
         data.correctPracticeDates = data.correctPracticeDates.slice(-Words.MAX_CORRECT_PRACTICE_DATES);
       }
@@ -247,16 +247,6 @@ export class Words {
     this.userInputs.set(word, value);
   }
 
-  get correct() {
-    const randomWords = this.getRandomWords();
-    return (
-      this.userInputs.size === randomWords.length &&
-      Array.from(this.userInputs.entries()).every(
-        ([word, value]) => word === value
-      )
-    );
-  }
-
   // Get random words weighted by practice priority
   getRandomWords(max: number = Words.MAX_RANDOM_WORDS): [string, string][] {
     const wordEntries = Array.from(this.wordData.entries());
@@ -282,16 +272,12 @@ export class Words {
 
     const selected: [string, string][] = [];
     const available = [...wordsWithPriority];
+    let totalPriority = available.reduce(
+      (sum, item) => sum + item.priority,
+      0
+    );
 
-    for (let i = 0; i < Math.min(max, wordEntries.length); i++) {
-      if (available.length === 0) break;
-
-      // Calculate total priority
-      const totalPriority = available.reduce(
-        (sum, item) => sum + item.priority,
-        0
-      );
-
+    for (let i = 0; i < Math.min(max, available.length); i++) {
       // Random selection based on priority
       let random = Math.random() * totalPriority;
       let selectedIndex = 0;
@@ -307,6 +293,7 @@ export class Words {
       const selectedItem = available[selectedIndex];
       selected.push([selectedItem.word, selectedItem.translation]);
       available.splice(selectedIndex, 1);
+      totalPriority -= selectedItem.priority;
     }
 
     return selected;
@@ -357,6 +344,78 @@ const commitBatchOperations = async (
   }
 };
 
+const parseWordDoc = (id: string, data: DocumentData): WordData => {
+  const inputTimes = data.inputTimes ?? [];
+  const lastPracticedAt = data.lastPracticedAt?.toDate() ?? null;
+
+  return {
+    word: data.word,
+    translation: data.translation,
+    correctCount: data.correctCount ?? 0,
+    totalAttempts: data.totalAttempts ?? 0,
+    inputTimes,
+    lastPracticedAt,
+    correctPracticeDates: (data.correctPracticeDates ?? []).map(
+      getLocalPracticeDate
+    ),
+    createdAt: data.createdAt?.toDate() ?? new Date(),
+    id,
+  };
+};
+
+const isWordDataEqual = (a: WordData, b: WordData) => {
+  if (
+    a.id !== b.id ||
+    a.translation !== b.translation ||
+    a.correctCount !== b.correctCount ||
+    a.totalAttempts !== b.totalAttempts ||
+    a.lastPracticedAt?.getTime() !== b.lastPracticedAt?.getTime() ||
+    a.createdAt?.getTime() !== b.createdAt?.getTime() ||
+    a.inputTimes.length !== b.inputTimes.length ||
+    a.correctPracticeDates.length !== b.correctPracticeDates.length
+  ) {
+    return false;
+  }
+  return (
+    a.inputTimes.every((time, i) => time === b.inputTimes[i]) &&
+    a.correctPracticeDates.every(
+      (date, i) => date === b.correctPracticeDates[i]
+    )
+  );
+};
+
+// 增量合并快照与本地 store，仅更新发生变化的单词，避免全量替换导致所有 observer 重渲染
+const mergeSnapshotIntoStore = (snapshot: {
+  docs: Array<{ id: string; data: () => DocumentData }>;
+}) => {
+  const incoming = new Map<string, WordData>();
+  snapshot.docs.forEach((doc) => {
+    incoming.set(doc.data().word, parseWordDoc(doc.id, doc.data()));
+  });
+
+  let changed = false;
+
+  for (const word of Array.from(words.wordData.keys())) {
+    if (!incoming.has(word)) {
+      words.deleteWord(word);
+      changed = true;
+    }
+  }
+
+  for (const [word, data] of incoming) {
+    const existing = words.wordData.get(word);
+    if (!existing) {
+      words.setWordData(word, data);
+      changed = true;
+    } else if (!isWordDataEqual(existing, data)) {
+      words.setWordData(word, data);
+      changed = true;
+    }
+  }
+
+  if (changed) words.invalidateCaches();
+};
+
 const words = new Words();
 
 interface WordsContextValue {
@@ -383,6 +442,7 @@ export const WordsProvider: FC<{ children: ReactNode }> = ({ children }) => {
   const [error, setError] = useState<string | null>(null);
   const [syncing, setSyncing] = useState(false);
   const [pendingCount, setPendingCount] = useState(0);
+  const syncingRef = useRef(false);
 
   useEffect(() => {
     if (!user) {
@@ -400,30 +460,15 @@ export const WordsProvider: FC<{ children: ReactNode }> = ({ children }) => {
       return onSnapshot(
         wordsCollection,
         (snapshot) => {
-          const wordsData: WordData[] = snapshot.docs.map((doc) => {
-            const data = doc.data();
-            const inputTimes = data.inputTimes ?? [];
-            const lastPracticedAt = data.lastPracticedAt?.toDate() ?? null;
-
-            return {
-              word: data.word,
-              translation: data.translation,
-              correctCount: data.correctCount ?? 0,
-              totalAttempts: data.totalAttempts ?? 0,
-              inputTimes,
-              lastPracticedAt,
-              correctPracticeDates: data.correctPracticeDates ?? [],
-              createdAt: data.createdAt?.toDate() ?? new Date(),
-              id: doc.id,
-            };
-          });
-          words.setWords(wordsData);
+          mergeSnapshotIntoStore(snapshot);
 
           // Clean up stale sync queue items
           // If Firestore data matches or exceeds queue data, remove from queue
           const queue = SyncQueueManager.getQueue();
           if (queue.length > 0) {
-            const wordsById = new Map(wordsData.map((w) => [w.id, w]));
+            const wordsById = new Map(
+              snapshot.docs.map((doc) => [doc.id, parseWordDoc(doc.id, doc.data())])
+            );
             const staleIds = new Set<string>();
             queue.forEach((item) => {
               const firestoreWord = wordsById.get(item.wordId);
@@ -608,11 +653,17 @@ export const WordsProvider: FC<{ children: ReactNode }> = ({ children }) => {
       return;
     }
 
+    // 防止定时器/页面可见性/网络恢复/手动触发并发执行导致队列竞争
+    if (syncingRef.current) {
+      return;
+    }
+
     const queue = SyncQueueManager.getQueue();
     if (queue.length === 0) {
       return;
     }
 
+    syncingRef.current = true;
     setSyncing(true);
 
     try {
@@ -668,10 +719,10 @@ export const WordsProvider: FC<{ children: ReactNode }> = ({ children }) => {
 
         try {
           await batch.commit();
-          queueItemIds.forEach((id) => SyncQueueManager.removeFromQueue(id));
+          SyncQueueManager.removeFromQueue(queueItemIds);
         } catch (error) {
           console.error("Failed to sync batch:", error);
-          queueItemIds.forEach((id) => SyncQueueManager.incrementRetry(id));
+          SyncQueueManager.incrementRetries(queueItemIds);
         }
       }
 
@@ -681,6 +732,7 @@ export const WordsProvider: FC<{ children: ReactNode }> = ({ children }) => {
       setPendingCount(SyncQueueManager.getUniqueWordCount());
     } finally {
       setSyncing(false);
+      syncingRef.current = false;
     }
   }, [user]);
 

--- a/apps/web/src/lib/masteryCalculator.test.ts
+++ b/apps/web/src/lib/masteryCalculator.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+import {
+  calculateMasteryScore,
+  getExpectedInputTime,
+  getMasteryLevel,
+  getMasteryLevelIndex,
+} from "./masteryCalculator";
+
+describe("getExpectedInputTime", () => {
+  it("短词使用固定值", () => {
+    expect(getExpectedInputTime(3)).toBe(1.5);
+    expect(getExpectedInputTime(5)).toBe(2.0);
+  });
+
+  it("长词按长度线性估算", () => {
+    expect(getExpectedInputTime(6)).toBeCloseTo(6 * 0.35 + 0.5);
+    expect(getExpectedInputTime(9)).toBeCloseTo(9 * 0.4 + 0.5);
+  });
+});
+
+describe("calculateMasteryScore", () => {
+  const baseWord = {
+    word: "apple",
+    correctCount: 0,
+    totalAttempts: 0,
+    inputTimes: [],
+    lastPracticedAt: null,
+    correctPracticeDates: [],
+  };
+
+  it("无练习记录时为 new 且 0 分", () => {
+    const result = calculateMasteryScore(baseWord);
+    expect(result.score).toBe(0);
+    expect(result.level).toBe("new");
+  });
+
+  it("尝试次数不足 3 时封顶 39 分", () => {
+    const result = calculateMasteryScore({
+      ...baseWord,
+      correctCount: 2,
+      totalAttempts: 2,
+      inputTimes: [2, 2],
+      correctPracticeDates: ["2026-08-14"],
+    });
+    expect(result.score).toBeLessThanOrEqual(39);
+    expect(result.level).not.toBe("mastered");
+  });
+
+  it("尝试次数不足 5 或复习天数不足 2 时封顶 59 分", () => {
+    const result = calculateMasteryScore({
+      ...baseWord,
+      correctCount: 4,
+      totalAttempts: 4,
+      inputTimes: [2, 2, 2, 2],
+      correctPracticeDates: ["2026-08-14"],
+    });
+    expect(result.score).toBeLessThanOrEqual(59);
+  });
+
+  it("8 次全对且复习 3 天达到已掌握", () => {
+    const result = calculateMasteryScore({
+      ...baseWord,
+      correctCount: 8,
+      totalAttempts: 8,
+      inputTimes: [2, 2, 2, 2, 2, 2, 2, 2],
+      lastPracticedAt: new Date("2026-08-15T10:00:00Z"),
+      correctPracticeDates: ["2026-08-12", "2026-08-13", "2026-08-14"],
+    });
+    expect(result.score).toBeGreaterThanOrEqual(80);
+    expect(result.level).toBe("mastered");
+  });
+
+  it("重复同一天只算一个复习日", () => {
+    const result = calculateMasteryScore({
+      ...baseWord,
+      correctCount: 8,
+      totalAttempts: 8,
+      inputTimes: [2, 2, 2, 2, 2, 2, 2, 2],
+      correctPracticeDates: ["2026-08-14", "2026-08-14", "2026-08-14"],
+    });
+    expect(result.reviewScore).toBeLessThanOrEqual(33);
+  });
+
+  it("分数始终限制在 0-100", () => {
+    const result = calculateMasteryScore({
+      ...baseWord,
+      correctCount: 3,
+      totalAttempts: 3,
+      inputTimes: [100, 100, 100],
+      correctPracticeDates: ["2026-08-14"],
+    });
+    expect(result.score).toBeGreaterThanOrEqual(0);
+    expect(result.score).toBeLessThanOrEqual(100);
+  });
+});
+
+describe("getMasteryLevel", () => {
+  it("正确映射等级", () => {
+    expect(getMasteryLevel(0)).toBe("new");
+    expect(getMasteryLevel(19)).toBe("new");
+    expect(getMasteryLevel(20)).toBe("learning");
+    expect(getMasteryLevel(40)).toBe("familiar");
+    expect(getMasteryLevel(60)).toBe("proficient");
+    expect(getMasteryLevel(80)).toBe("mastered");
+    expect(getMasteryLevel(100)).toBe("mastered");
+  });
+});
+
+describe("getMasteryLevelIndex", () => {
+  it("正确映射等级索引", () => {
+    expect(getMasteryLevelIndex(0)).toBe(0);
+    expect(getMasteryLevelIndex(20)).toBe(1);
+    expect(getMasteryLevelIndex(40)).toBe(2);
+    expect(getMasteryLevelIndex(60)).toBe(3);
+    expect(getMasteryLevelIndex(80)).toBe(4);
+  });
+});

--- a/apps/web/src/lib/parseTranslation.test.ts
+++ b/apps/web/src/lib/parseTranslation.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { parseTranslation } from "./parseTranslation";
+
+describe("parseTranslation", () => {
+  it("空字符串返回空", () => {
+    expect(parseTranslation("")).toEqual({
+      englishDefinition: "",
+      chineseTranslation: "",
+    });
+    expect(parseTranslation("  \n  ")).toEqual({
+      englishDefinition: "",
+      chineseTranslation: "",
+    });
+  });
+
+  it("单行中文作为中文翻译", () => {
+    expect(parseTranslation("苹果")).toEqual({
+      englishDefinition: "",
+      chineseTranslation: "苹果",
+    });
+  });
+
+  it("单行英文作为英文释义", () => {
+    expect(parseTranslation("a round fruit")).toEqual({
+      englishDefinition: "a round fruit",
+      chineseTranslation: "",
+    });
+  });
+
+  it("多行时首行为英文释义，其余为中文翻译", () => {
+    expect(parseTranslation("a round fruit\n苹果")).toEqual({
+      englishDefinition: "a round fruit",
+      chineseTranslation: "苹果",
+    });
+  });
+
+  it("中文翻译多行时合并保留换行", () => {
+    expect(parseTranslation("a round fruit\n苹果\n一种水果")).toEqual({
+      englishDefinition: "a round fruit",
+      chineseTranslation: "苹果\n一种水果",
+    });
+  });
+
+  it("去除多余空白", () => {
+    expect(parseTranslation("  a round fruit \n 苹果 ")).toEqual({
+      englishDefinition: "a round fruit",
+      chineseTranslation: "苹果",
+    });
+  });
+});

--- a/apps/web/src/lib/parseTranslation.ts
+++ b/apps/web/src/lib/parseTranslation.ts
@@ -1,0 +1,28 @@
+export interface ParsedTranslation {
+  englishDefinition: string;
+  chineseTranslation: string;
+}
+
+export const parseTranslation = (translation: string): ParsedTranslation => {
+  const segments = translation
+    .split("\n")
+    .map((segment) => segment.trim())
+    .filter(Boolean);
+
+  if (segments.length === 0) {
+    return { englishDefinition: "", chineseTranslation: "" };
+  }
+
+  if (segments.length === 1) {
+    const single = segments[0];
+    const hasChinese = /[\u4e00-\u9fff]/.test(single);
+    return hasChinese
+      ? { englishDefinition: "", chineseTranslation: single }
+      : { englishDefinition: single, chineseTranslation: "" };
+  }
+
+  return {
+    englishDefinition: segments[0],
+    chineseTranslation: segments.slice(1).join("\n"),
+  };
+};

--- a/apps/web/src/lib/practiceDate.test.ts
+++ b/apps/web/src/lib/practiceDate.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { formatLocalPracticeDate, getLocalPracticeDate } from "./practiceDate";
+
+describe("formatLocalPracticeDate", () => {
+  it("格式化为 YYYY-MM-DD", () => {
+    const date = new Date(2026, 7, 15, 10, 30);
+    expect(formatLocalPracticeDate(date)).toBe("2026-08-15");
+  });
+});
+
+describe("getLocalPracticeDate", () => {
+  it("YYYY-MM-DD 直接返回（避免负时区解析偏移）", () => {
+    expect(getLocalPracticeDate("2026-08-15")).toBe("2026-08-15");
+  });
+
+  it("ISO 字符串转换为本地日期", () => {
+    const iso = new Date(2026, 7, 15, 10, 30).toISOString();
+    expect(getLocalPracticeDate(iso)).toBe("2026-08-15");
+  });
+
+  it("非法字符串原样返回", () => {
+    expect(getLocalPracticeDate("not-a-date")).toBe("not-a-date");
+  });
+});

--- a/apps/web/src/lib/practiceDate.ts
+++ b/apps/web/src/lib/practiceDate.ts
@@ -6,6 +6,10 @@ export const formatLocalPracticeDate = (date: Date) => {
 };
 
 export const getLocalPracticeDate = (practiceDate: string) => {
+  // 已是本地日期格式（YYYY-MM-DD），直接返回，避免 new Date 在负时区解析偏移
+  if (/^\d{4}-\d{2}-\d{2}$/.test(practiceDate)) {
+    return practiceDate;
+  }
   const date = new Date(practiceDate);
   return Number.isNaN(date.getTime())
     ? practiceDate

--- a/apps/web/src/lib/sentenceCompare.test.ts
+++ b/apps/web/src/lib/sentenceCompare.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { normalizeForComparison } from "./sentenceCompare";
+
+describe("normalizeForComparison", () => {
+  it("忽略大小写", () => {
+    expect(normalizeForComparison("Hello")).toBe("hello");
+  });
+
+  it("忽略标点", () => {
+    expect(normalizeForComparison("Hello, world!")).toBe("hello world");
+  });
+
+  it("合并多余空白", () => {
+    expect(normalizeForComparison("hello   world")).toBe("hello world");
+    expect(normalizeForComparison("  hello world  ")).toBe("hello world");
+  });
+
+  it("保留中文字符", () => {
+    expect(normalizeForComparison("Hello 世界")).toBe("hello 世界");
+  });
+
+  it("完全相同的句子归一化后相等", () => {
+    const a = normalizeForComparison("I love apple!");
+    const b = normalizeForComparison("  i LOVE apple ");
+    expect(a).toBe(b);
+  });
+});

--- a/apps/web/src/lib/sentenceCompare.ts
+++ b/apps/web/src/lib/sentenceCompare.ts
@@ -1,0 +1,6 @@
+export const normalizeForComparison = (value: string) =>
+  value
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}\s]/gu, " ")
+    .replace(/\s+/g, " ")
+    .trim();

--- a/apps/web/src/lib/syncQueue.ts
+++ b/apps/web/src/lib/syncQueue.ts
@@ -53,27 +53,33 @@ export class SyncQueueManager {
   }
   
   // 从队列移除
-  static removeFromQueue(id: string): void {
+  static removeFromQueue(ids: string[]): void {
+    if (ids.length === 0) return;
     const queue = this.getQueue();
-    const filtered = queue.filter(item => item.id !== id);
-    this.saveQueue(filtered);
+    const idSet = new Set(ids);
+    const filtered = queue.filter(item => !idSet.has(item.id));
+    if (filtered.length !== queue.length) {
+      this.saveQueue(filtered);
+    }
   }
   
-  // 更新重试次数
-  static incrementRetry(id: string): boolean {
+  // 更新重试次数（达到最大重试次数的自动移除）
+  static incrementRetries(ids: string[]): void {
+    if (ids.length === 0) return;
     const queue = this.getQueue();
-    const item = queue.find(item => item.id === id);
-    if (item) {
-      item.retryCount++;
-      if (item.retryCount >= this.MAX_RETRIES) {
-        // 达到最大重试次数，移除
-        this.removeFromQueue(id);
-        return false;
+    const idSet = new Set(ids);
+    const remaining: SyncQueueItem[] = [];
+    for (const item of queue) {
+      if (idSet.has(item.id)) {
+        item.retryCount++;
+        if (item.retryCount >= this.MAX_RETRIES) {
+          // 达到最大重试次数，移除
+          continue;
+        }
       }
-      this.saveQueue(queue);
-      return true;
+      remaining.push(item);
     }
-    return false;
+    this.saveQueue(remaining);
   }
   
   // 清空队列

--- a/apps/web/vitest.config.mts
+++ b/apps/web/vitest.config.mts
@@ -1,0 +1,13 @@
+import path from "node:path";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(process.cwd(), "src"),
+    },
+  },
+  test: {
+    environment: "node",
+  },
+});

--- a/bun.lock
+++ b/bun.lock
@@ -38,6 +38,7 @@
         "eslint-config-next": "^16.0.1",
         "typescript": "^5.9.3",
         "vercel": "^58.0.0",
+        "vitest": "^4.1.10",
       },
     },
   },
@@ -530,6 +531,10 @@
 
     "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.0-rc.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-UvApLEGholmxw/HIwmUnLq3CwdydbhaHHllvWiCTNbyGom7wTwOtz5OAQbAKZYyiEOeIXZNPkM7nA4Dtng7CLw=="],
 
+    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-GjbjXD4XXfN19D0LZNbmiCBUoDiRACsYHr0yaIbbn8aFsXjHZifcYqu/W5Er5X2X990WjHXFrxarn5chzItorQ=="],
+
+    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-p5WR0NOwaRmJ/B1b6IjEFLLivwEsf3PrdBIhRbhTCQisbo2SvHHpG4ELB/+FgQNnB88LTOF86upmJmbvZdQ2lw=="],
+
     "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.0-rc.1", "", { "os": "linux", "cpu": "x64" }, "sha512-uVctNgZHiGnJx5Fij7wHLhgw4uyZBVi6mykeWKOqE7bVy9Hcxn0fM/IuqdMwk6hXlaf9fFShDTFz2+YejP+x0A=="],
 
     "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.0-rc.1", "", { "os": "linux", "cpu": "x64" }, "sha512-T6Eg0xWwcxd/MzBcuv4Z37YVbUbJxy5cMNnbIt/Yr99wFwli30O4BPlY8hKeGyn6lWNtU0QioBS46lVzDN38bg=="],
@@ -549,6 +554,8 @@
     "@rtsao/scc": ["@rtsao/scc@1.1.0", "", {}, "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g=="],
 
     "@sinclair/typebox": ["@sinclair/typebox@0.25.24", "", {}, "sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ=="],
+
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
 
@@ -589,6 +596,10 @@
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
     "@types/caseless": ["@types/caseless@0.12.5", "", {}, "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg=="],
+
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
@@ -750,6 +761,20 @@
 
     "@vercel/vc-native-linux-x64": ["@vercel/vc-native-linux-x64@58.9.1", "", { "os": "linux", "cpu": "x64" }, "sha512-bdNhjCXIpX69Cmi7yGvB4E6Myq/UXT9zy0cazDFjdfNWrixYJ/qx+50jJfKw8oGlL6PCkKW2oawD5aVicYxvwg=="],
 
+    "@vitest/expect": ["@vitest/expect@4.1.10", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.10", "@vitest/utils": "4.1.10", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA=="],
+
+    "@vitest/mocker": ["@vitest/mocker@4.1.10", "", { "dependencies": { "@vitest/spy": "4.1.10", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.10", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q=="],
+
+    "@vitest/runner": ["@vitest/runner@4.1.10", "", { "dependencies": { "@vitest/utils": "4.1.10", "pathe": "^2.0.3" } }, "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.10", "", { "dependencies": { "@vitest/pretty-format": "4.1.10", "@vitest/utils": "4.1.10", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw=="],
+
+    "@vitest/spy": ["@vitest/spy@4.1.10", "", {}, "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw=="],
+
+    "@vitest/utils": ["@vitest/utils@4.1.10", "", { "dependencies": { "@vitest/pretty-format": "4.1.10", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA=="],
+
     "@workflow/serde": ["@workflow/serde@4.1.0-beta.2", "", {}, "sha512-8kkeoQKLDaKXefjV5dbhBj2aErfKp1Mc4pb6tj8144cF+Em5SPbyMbyLCHp+BVrFfFVCBluCtMx+jjvaFVZGww=="],
 
     "abbrev": ["abbrev@3.0.1", "", {}, "sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg=="],
@@ -799,6 +824,8 @@
     "arraybuffer.prototype.slice": ["arraybuffer.prototype.slice@1.0.4", "", { "dependencies": { "array-buffer-byte-length": "^1.0.1", "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.5", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "is-array-buffer": "^3.0.4" } }, "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ=="],
 
     "arrify": ["arrify@2.0.1", "", {}, "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
     "ast-types-flow": ["ast-types-flow@0.0.8", "", {}, "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ=="],
 
@@ -853,6 +880,8 @@
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001774", "", {}, "sha512-DDdwPGz99nmIEv216hKSgLD+D4ikHQHjBC/seF98N9CPqRX4M5mSxT9eTV6oyisnJcuzxtZy4n17yKKQYmYQOA=="],
+
+    "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -946,7 +975,7 @@
 
     "es-iterator-helpers": ["es-iterator-helpers@1.2.2", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.4", "define-properties": "^1.2.1", "es-abstract": "^1.24.1", "es-errors": "^1.3.0", "es-set-tostringtag": "^2.1.0", "function-bind": "^1.1.2", "get-intrinsic": "^1.3.0", "globalthis": "^1.0.4", "gopd": "^1.2.0", "has-property-descriptors": "^1.0.2", "has-proto": "^1.2.0", "has-symbols": "^1.1.0", "internal-slot": "^1.1.0", "iterator.prototype": "^1.1.5", "safe-array-concat": "^1.1.3" } }, "sha512-BrUQ0cPTB/IwXj23HtwHjS9n7O4h9FX94b4xc5zlTHxeLgTAdzYUDyy6KdExAl9lbN5rtfe44xpjpmj9grxs5w=="],
 
-    "es-module-lexer": ["es-module-lexer@1.5.0", "", {}, "sha512-pqrTKmwEIgafsYZAGw9kszYzmagcE/n4dbgwGWLEXg7J4QFJVQRBld8j3Q3GNez79jzxZshq0bcT962QHOghjw=="],
+    "es-module-lexer": ["es-module-lexer@2.3.1", "", {}, "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA=="],
 
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
@@ -992,7 +1021,7 @@
 
     "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
 
-    "estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
@@ -1005,6 +1034,8 @@
     "events-universal": ["events-universal@1.0.1", "", { "dependencies": { "bare-events": "^2.7.0" } }, "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw=="],
 
     "execa": ["execa@3.2.0", "", { "dependencies": { "cross-spawn": "^7.0.0", "get-stream": "^5.0.0", "human-signals": "^1.1.1", "is-stream": "^2.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^4.0.0", "onetime": "^5.1.0", "p-finally": "^2.0.0", "signal-exit": "^3.0.2", "strip-final-newline": "^2.0.0" } }, "sha512-kJJfVbI/lZE1PZYDI5VPxp8zXPO9rtxOkhpZ0jMKha56AI9y2gGVC6bkukStQf0ka5Rh15BA5m7cCCH4jmHqkw=="],
+
+    "expect-type": ["expect-type@1.4.0", "", {}, "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA=="],
 
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
@@ -1278,29 +1309,29 @@
 
     "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
 
-    "lightningcss": ["lightningcss@1.31.1", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.31.1", "lightningcss-darwin-arm64": "1.31.1", "lightningcss-darwin-x64": "1.31.1", "lightningcss-freebsd-x64": "1.31.1", "lightningcss-linux-arm-gnueabihf": "1.31.1", "lightningcss-linux-arm64-gnu": "1.31.1", "lightningcss-linux-arm64-musl": "1.31.1", "lightningcss-linux-x64-gnu": "1.31.1", "lightningcss-linux-x64-musl": "1.31.1", "lightningcss-win32-arm64-msvc": "1.31.1", "lightningcss-win32-x64-msvc": "1.31.1" } }, "sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ=="],
+    "lightningcss": ["lightningcss@1.33.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.33.0", "lightningcss-darwin-arm64": "1.33.0", "lightningcss-darwin-x64": "1.33.0", "lightningcss-freebsd-x64": "1.33.0", "lightningcss-linux-arm-gnueabihf": "1.33.0", "lightningcss-linux-arm64-gnu": "1.33.0", "lightningcss-linux-arm64-musl": "1.33.0", "lightningcss-linux-x64-gnu": "1.33.0", "lightningcss-linux-x64-musl": "1.33.0", "lightningcss-win32-arm64-msvc": "1.33.0", "lightningcss-win32-x64-msvc": "1.33.0" } }, "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA=="],
 
-    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.31.1", "", { "os": "android", "cpu": "arm64" }, "sha512-HXJF3x8w9nQ4jbXRiNppBCqeZPIAfUo8zE/kOEGbW5NZvGc/K7nMxbhIr+YlFlHW5mpbg/YFPdbnCh1wAXCKFg=="],
+    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.33.0", "", { "os": "android", "cpu": "arm64" }, "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg=="],
 
-    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.31.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-02uTEqf3vIfNMq3h/z2cJfcOXnQ0GRwQrkmPafhueLb2h7mqEidiCzkE4gBMEH65abHRiQvhdcQ+aP0D0g67sg=="],
+    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.33.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg=="],
 
-    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.31.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-1ObhyoCY+tGxtsz1lSx5NXCj3nirk0Y0kB/g8B8DT+sSx4G9djitg9ejFnjb3gJNWo7qXH4DIy2SUHvpoFwfTA=="],
+    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.33.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ=="],
 
-    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.31.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-1RINmQKAItO6ISxYgPwszQE1BrsVU5aB45ho6O42mu96UiZBxEXsuQ7cJW4zs4CEodPUioj/QrXW1r9pLUM74A=="],
+    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.33.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg=="],
 
-    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.31.1", "", { "os": "linux", "cpu": "arm" }, "sha512-OOCm2//MZJ87CdDK62rZIu+aw9gBv4azMJuA8/KB74wmfS3lnC4yoPHm0uXZ/dvNNHmnZnB8XLAZzObeG0nS1g=="],
+    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.33.0", "", { "os": "linux", "cpu": "arm" }, "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ=="],
 
-    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.31.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-WKyLWztD71rTnou4xAD5kQT+982wvca7E6QoLpoawZ1gP9JM0GJj4Tp5jMUh9B3AitHbRZ2/H3W5xQmdEOUlLg=="],
+    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.33.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg=="],
 
-    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.31.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg=="],
+    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.33.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ=="],
 
-    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.31.1", "", { "os": "linux", "cpu": "x64" }, "sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA=="],
+    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.33.0", "", { "os": "linux", "cpu": "x64" }, "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg=="],
 
-    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.31.1", "", { "os": "linux", "cpu": "x64" }, "sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA=="],
+    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.33.0", "", { "os": "linux", "cpu": "x64" }, "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw=="],
 
-    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.31.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w=="],
+    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.33.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA=="],
 
-    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.31.1", "", { "os": "win32", "cpu": "x64" }, "sha512-I9aiFrbd7oYHwlnQDqr1Roz+fTz61oDDJX7n9tYF9FJymH1cIN1DtKw3iYt6b8WZgEjoNwVSncwF4wx/ZedMhw=="],
+    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.33.0", "", { "os": "win32", "cpu": "x64" }, "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA=="],
 
     "limiter": ["limiter@1.1.5", "", {}, "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA=="],
 
@@ -1414,6 +1445,8 @@
 
     "object.values": ["object.values@1.2.1", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0" } }, "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA=="],
 
+    "obug": ["obug@2.1.4", "", {}, "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA=="],
+
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
     "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
@@ -1453,6 +1486,8 @@
     "path-to-regexp": ["path-to-regexp@8.3.0", "", {}, "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="],
 
     "path-to-regexp-updated": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
     "pend": ["pend@1.2.0", "", {}, "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="],
 
@@ -1570,6 +1605,8 @@
 
     "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
     "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
     "smol-toml": ["smol-toml@1.5.2", "", {}, "sha512-QlaZEqcAH3/RtNyet1IPIYPsEWAaYyXXv1Krsi+1L/QHppjX4Ifm8MQsBISz9vE8cHicIq3clogsheili5vhaQ=="],
@@ -1580,9 +1617,13 @@
 
     "stable-hash": ["stable-hash@0.0.5", "", {}, "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA=="],
 
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
     "stat-mode": ["stat-mode@0.3.0", "", {}, "sha512-QjMLR0A3WwFY2aZdV0okfFEJB5TRjkggXZjxP3A1RsWsNHNu3YPv8btmtc6iCFZ0Rul3FE93OYogvhOUClU+ng=="],
 
     "statuses": ["statuses@1.5.0", "", {}, "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA=="],
+
+    "std-env": ["std-env@4.2.0", "", {}, "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw=="],
 
     "stop-iteration-iterator": ["stop-iteration-iterator@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "internal-slot": "^1.1.0" } }, "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ=="],
 
@@ -1648,9 +1689,13 @@
 
     "time-span": ["time-span@4.0.0", "", { "dependencies": { "convert-hrtime": "^3.0.0" } }, "sha512-MyqZCTGLDZ77u4k+jqg4UlrzPTPZ49NDlaekU6uuFaJLzPIN1woaRXCbGeqOfxwc3Y37ZROGAJ614Rdv7Olt+g=="],
 
-    "tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@1.3.0", "", {}, "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ=="],
 
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+
+    "tinyrainbow": ["tinyrainbow@3.1.1", "", {}, "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
@@ -1730,6 +1775,10 @@
 
     "vercel": ["vercel@58.9.1", "", { "dependencies": { "@vercel/backends": "0.8.35", "@vercel/blob": "2.4.0", "@vercel/build-utils": "14.0.4", "@vercel/cli-auth": "0.3.3", "@vercel/cli-config": "0.2.3", "@vercel/container": "0.1.1", "@vercel/detect-agent": "1.2.4", "@vercel/elysia": "0.1.112", "@vercel/express": "0.1.126", "@vercel/fastify": "0.1.115", "@vercel/fun": "1.3.0", "@vercel/go": "3.10.4", "@vercel/h3": "0.1.121", "@vercel/hono": "0.2.115", "@vercel/hydrogen": "1.4.1", "@vercel/koa": "0.1.95", "@vercel/nestjs": "0.2.116", "@vercel/next": "4.21.3", "@vercel/node": "5.9.8", "@vercel/prepare-flags-definitions": "0.3.0", "@vercel/python": "6.56.0", "@vercel/redwood": "2.5.1", "@vercel/remix-builder": "5.9.2", "@vercel/ruby": "2.5.1", "@vercel/rust": "1.4.1", "@vercel/static-build": "2.12.4", "chokidar": "4.0.0", "esbuild": "0.27.0", "jose": "5.9.6", "jsonc-parser": "3.3.1", "luxon": "^3.4.0", "sandbox": "3.4.0", "smol-toml": "1.5.2", "undici": "5.29.0", "uuid": "14.0.1", "zod": "4.1.11" }, "optionalDependencies": { "@vercel/vc-native-darwin-arm64": "58.9.1", "@vercel/vc-native-darwin-x64": "58.9.1", "@vercel/vc-native-linux-arm64": "58.9.1", "@vercel/vc-native-linux-x64": "58.9.1" }, "bin": { "vc": "dist/vc.js", "vercel": "dist/vc.js" } }, "sha512-CzFE2wffZjTbYVeRFpwcIWhUAk9CFMcCy7XqISZJ1RtuZz2fRz96ycUJlWZeOvYFgFTfpDFQUnX1PMjEPkoBXQ=="],
 
+    "vite": ["vite@8.2.1", "", { "dependencies": { "lightningcss": "^1.33.0", "picomatch": "^4.0.5", "postcss": "^8.5.25", "rolldown": "~1.2.1", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.4.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw=="],
+
+    "vitest": ["vitest@4.1.10", "", { "dependencies": { "@vitest/expect": "4.1.10", "@vitest/mocker": "4.1.10", "@vitest/pretty-format": "4.1.10", "@vitest/runner": "4.1.10", "@vitest/snapshot": "4.1.10", "@vitest/spy": "4.1.10", "@vitest/utils": "4.1.10", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.10", "@vitest/browser-preview": "4.1.10", "@vitest/browser-webdriverio": "4.1.10", "@vitest/coverage-istanbul": "4.1.10", "@vitest/coverage-v8": "4.1.10", "@vitest/ui": "4.1.10", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw=="],
+
     "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
 
     "web-vitals": ["web-vitals@4.2.4", "", {}, "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw=="],
@@ -1751,6 +1800,8 @@
     "which-collection": ["which-collection@1.0.2", "", { "dependencies": { "is-map": "^2.0.3", "is-set": "^2.0.3", "is-weakmap": "^2.0.2", "is-weakset": "^2.0.3" } }, "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw=="],
 
     "which-typed-array": ["which-typed-array@1.1.20", "", { "dependencies": { "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.4", "for-each": "^0.3.5", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2" } }, "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
@@ -1816,6 +1867,10 @@
 
     "@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.1", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@tybys/wasm-util": "^0.10.1" } }, "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A=="],
 
+    "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
+
+    "@tailwindcss/node/lightningcss": ["lightningcss@1.31.1", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.31.1", "lightningcss-darwin-arm64": "1.31.1", "lightningcss-darwin-x64": "1.31.1", "lightningcss-freebsd-x64": "1.31.1", "lightningcss-linux-arm-gnueabihf": "1.31.1", "lightningcss-linux-arm64-gnu": "1.31.1", "lightningcss-linux-arm64-musl": "1.31.1", "lightningcss-linux-x64-gnu": "1.31.1", "lightningcss-linux-x64-musl": "1.31.1", "lightningcss-win32-arm64-msvc": "1.31.1", "lightningcss-win32-x64-msvc": "1.31.1" } }, "sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ=="],
+
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
@@ -1838,6 +1893,8 @@
 
     "@vercel/blob/undici": ["undici@6.23.0", "", {}, "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g=="],
 
+    "@vercel/build-utils/es-module-lexer": ["es-module-lexer@1.5.0", "", {}, "sha512-pqrTKmwEIgafsYZAGw9kszYzmagcE/n4dbgwGWLEXg7J4QFJVQRBld8j3Q3GNez79jzxZshq0bcT962QHOghjw=="],
+
     "@vercel/express/zod": ["zod@3.22.4", "", {}, "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg=="],
 
     "@vercel/fun/async-listen": ["async-listen@1.2.0", "", {}, "sha512-CcEtRh/oc9Jc4uWeUwdpG/+Mb2YUHKmdaTf0gUr7Wa+bfp4xx70HOb3RuSTJMvqKNB1TkdTfjLdrcz2X4rkkZA=="],
@@ -1850,9 +1907,13 @@
 
     "@vercel/fun/semver": ["semver@7.5.4", "", { "dependencies": { "lru-cache": "^6.0.0" }, "bin": { "semver": "bin/semver.js" } }, "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA=="],
 
+    "@vercel/fun/tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
+
     "@vercel/gatsby-plugin-vercel-analytics/web-vitals": ["web-vitals@0.2.4", "", {}, "sha512-6BjspCO9VriYy12z356nL6JBS0GYeEcA457YyRzD+dD6XYCQ75NKhcOHUMHentOE7OcVCIXXDvOm0jKFfQG2Gg=="],
 
     "@vercel/hono/zod": ["zod@3.22.4", "", {}, "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg=="],
+
+    "@vercel/nft/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
     "@vercel/nft/resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
 
@@ -1964,6 +2025,14 @@
 
     "undici/@fastify/busboy": ["@fastify/busboy@2.1.1", "", {}, "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="],
 
+    "vite/picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
+
+    "vite/postcss": ["postcss@8.5.26", "", { "dependencies": { "nanoid": "^3.3.17", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ=="],
+
+    "vite/rolldown": ["rolldown@1.2.4", "", { "dependencies": { "@oxc-project/types": "=0.144.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.2.4", "@rolldown/binding-darwin-arm64": "1.2.4", "@rolldown/binding-darwin-x64": "1.2.4", "@rolldown/binding-freebsd-x64": "1.2.4", "@rolldown/binding-linux-arm-gnueabihf": "1.2.4", "@rolldown/binding-linux-arm64-gnu": "1.2.4", "@rolldown/binding-linux-arm64-musl": "1.2.4", "@rolldown/binding-linux-ppc64-gnu": "1.2.4", "@rolldown/binding-linux-s390x-gnu": "1.2.4", "@rolldown/binding-linux-x64-gnu": "1.2.4", "@rolldown/binding-linux-x64-musl": "1.2.4", "@rolldown/binding-openharmony-arm64": "1.2.4", "@rolldown/binding-win32-arm64-msvc": "1.2.4", "@rolldown/binding-win32-x64-msvc": "1.2.4" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-rSr7irW0K7QRWzjdJXqZowkcRdDtjRduh43rBltnVKd0VFq839l1lJoDvGJb6gl7+4rTTCrPWu+YfujUL8Ug7w=="],
+
+    "vite/tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
     "@babel/helper-compilation-targets/lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "@google-cloud/storage/google-auth-library/gcp-metadata": ["gcp-metadata@6.1.1", "", { "dependencies": { "gaxios": "^6.1.1", "google-logging-utils": "^0.0.2", "json-bigint": "^1.0.0" } }, "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A=="],
@@ -1973,6 +2042,28 @@
     "@oxc-transform/binding-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
 
     "@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
+
+    "@tailwindcss/node/lightningcss/lightningcss-android-arm64": ["lightningcss-android-arm64@1.31.1", "", { "os": "android", "cpu": "arm64" }, "sha512-HXJF3x8w9nQ4jbXRiNppBCqeZPIAfUo8zE/kOEGbW5NZvGc/K7nMxbhIr+YlFlHW5mpbg/YFPdbnCh1wAXCKFg=="],
+
+    "@tailwindcss/node/lightningcss/lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.31.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-02uTEqf3vIfNMq3h/z2cJfcOXnQ0GRwQrkmPafhueLb2h7mqEidiCzkE4gBMEH65abHRiQvhdcQ+aP0D0g67sg=="],
+
+    "@tailwindcss/node/lightningcss/lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.31.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-1ObhyoCY+tGxtsz1lSx5NXCj3nirk0Y0kB/g8B8DT+sSx4G9djitg9ejFnjb3gJNWo7qXH4DIy2SUHvpoFwfTA=="],
+
+    "@tailwindcss/node/lightningcss/lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.31.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-1RINmQKAItO6ISxYgPwszQE1BrsVU5aB45ho6O42mu96UiZBxEXsuQ7cJW4zs4CEodPUioj/QrXW1r9pLUM74A=="],
+
+    "@tailwindcss/node/lightningcss/lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.31.1", "", { "os": "linux", "cpu": "arm" }, "sha512-OOCm2//MZJ87CdDK62rZIu+aw9gBv4azMJuA8/KB74wmfS3lnC4yoPHm0uXZ/dvNNHmnZnB8XLAZzObeG0nS1g=="],
+
+    "@tailwindcss/node/lightningcss/lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.31.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-WKyLWztD71rTnou4xAD5kQT+982wvca7E6QoLpoawZ1gP9JM0GJj4Tp5jMUh9B3AitHbRZ2/H3W5xQmdEOUlLg=="],
+
+    "@tailwindcss/node/lightningcss/lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.31.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg=="],
+
+    "@tailwindcss/node/lightningcss/lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.31.1", "", { "os": "linux", "cpu": "x64" }, "sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA=="],
+
+    "@tailwindcss/node/lightningcss/lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.31.1", "", { "os": "linux", "cpu": "x64" }, "sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA=="],
+
+    "@tailwindcss/node/lightningcss/lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.31.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w=="],
+
+    "@tailwindcss/node/lightningcss/lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.31.1", "", { "os": "win32", "cpu": "x64" }, "sha512-I9aiFrbd7oYHwlnQDqr1Roz+fTz61oDDJX7n9tYF9FJymH1cIN1DtKw3iYt6b8WZgEjoNwVSncwF4wx/ZedMhw=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg=="],
 
@@ -2007,6 +2098,36 @@
     "stream-to-promise/end-of-stream/once": ["once@1.3.3", "", { "dependencies": { "wrappy": "1" } }, "sha512-6vaNInhu+CHxtONf3zw3vq4SP2DOQhjBvIa3rNcG0+P7eKWlYH6Peu7rHizSloRU2EwMz6GraLieis9Ac9+p1w=="],
 
     "teeny-request/https-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
+
+    "vite/postcss/nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
+
+    "vite/rolldown/@oxc-project/types": ["@oxc-project/types@0.144.0", "", {}, "sha512-nuhZIOLuI6TFQ32I/WnUx+SCPY7SdSKwgnFHydAuoS1+Z4BRcaP+RRJmGzl9lw+0OFF7UmaESf7KQRXaNLHypg=="],
+
+    "vite/rolldown/@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.2.4", "", { "os": "android", "cpu": "arm64" }, "sha512-jHC2cnyKz5xU2fhECtFl8OZ83cYNt13GZQD+0uMJ/X3o+ijmd56okHhTUwxVSHPx1IRVIJEZ1/1pPzeLCU6XKA=="],
+
+    "vite/rolldown/@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Dc5mPD8F5F/FS8i01syd7FTF6yB2fVthH/TRkjwJkzUK6EpoxHtqvZQP5Zwq80/5z19TWYHIg1KOHboCgVx/aQ=="],
+
+    "vite/rolldown/@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-fpDm4oBo6SqLvWUYCmFhdde3U9KH2fRNNMeAnAPAIwxRL345xutL0EtEUcuoxsoazdJGv/MuDBQHlCDrtbvqOg=="],
+
+    "vite/rolldown/@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.2.4", "", { "os": "freebsd", "cpu": "x64" }, "sha512-rSJoreDE/HoIzoaib6MTp5jQtCTdMHKIvItAKT/ImS6Y6Ww76oUaeMyp4Vc/fAgd/ehji068IxetHXAnqUwN9A=="],
+
+    "vite/rolldown/@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-/jm8OGHgn7oGaJu3i/qZI9spUGcJ+y/lk43ttQ/iO1tOd9NissG6o97bighBCiL+BKRngmcDuR6ikfwYdJmVuQ=="],
+
+    "vite/rolldown/@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-tIP06BeD9EqvECBrPZ+sqdPlYrT+aYaAiu1wYziVx5elRK/ftm33JxVDy2bXGbr6J0CrtirCkR87/X5a2euEng=="],
+
+    "vite/rolldown/@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-Ql1Q0EQqVThvn9VAVlwNzsUvbSFtCMGjLpRRi4pk5i7NZZ4n5ISiLMjHYtus4VQ2PvkSw24zyaCVsiS+sXPj1w=="],
+
+    "vite/rolldown/@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-4/GyVjmhR+Tc6HLJvwc1sOhPqAZtySiSMesOZyX6JQ5XBxoTDEMKQzvo07NIK6nTon/SivlZqvhzvuVBNQhObQ=="],
+
+    "vite/rolldown/@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-l9eeLsCNvPpmSXUej0etw/J1eqV0Jj1D5G/xG6YTijmE6dkv6E2QezgWbTfQk63v952DPqrjOCoiqxq7Bw0YUQ=="],
+
+    "vite/rolldown/@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.2.4", "", { "os": "none", "cpu": "arm64" }, "sha512-e0F355MSTMm3+UOqtV3L24gFUp2N5m1f8L/7d56deik6va+AXdrt9F8LbzGpeWGWRbZEDq4m8NVnJDeBtf9DZg=="],
+
+    "vite/rolldown/@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.2.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-AWLi0uBRYh6QlE7OKhiz+phZC0qwtij2QZmhmOdsLdFn64m7oMpooE9ICE3lhm9xMb4SpDo2WbHcxX1iFLFtqw=="],
+
+    "vite/rolldown/@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.2.4", "", { "os": "win32", "cpu": "x64" }, "sha512-UwSDJOg3dqCAejWdxclJjCsh3Qq4vLYMDxmyHqo1btz3stK2VqgwNd3mm5tuIwzSlGIQ/1H9Hr+Zn09mrezNqQ=="],
+
+    "vite/rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
 
     "@google-cloud/storage/google-auth-library/gcp-metadata/google-logging-utils": ["google-logging-utils@0.0.2", "", {}, "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ=="],
 


### PR DESCRIPTION
## 背景

Web 端一系列优化，覆盖正确性风险、性能与工程质量。

## 变更内容

### 正确性 / Bug
- **`syncToFirestore` 防重入**：30s 定时器 + `visibilitychange` + `online` 事件 + 手动触发可能并发执行，导致同步队列 `removeFromQueue`/`incrementRetries` 交错竞争。加 `syncingRef` 互斥。
- **translate API 超时与缓存**：Google 翻译/DataMuse 免费端点无超时可能无限挂起；改为 8s 超时 + 1000 条服务端内存缓存，同词不再重复调用外部服务（顺带缓解限流额度消耗）。
- **删除 `Words.correct`**：未被使用且语义有缺陷（内部调用随机的 `getRandomWords()`，每次结果不同）。

### 性能
- **`onSnapshot` 增量合并**：`mergeSnapshotIntoStore` 只更新变化的单词、按需使缓存失效，避免全量重建 Map 导致所有 observer 重渲染。
- **`correctPracticeDates` 存 `YYYY-MM-DD`**：避免每次比较/计算的 `new Date` 解析，并消除负时区把日期解析偏移一天的隐患；`getLocalPracticeDate` 对纯日期字符串短路。
- **同步队列批量清理**：每 batch 只做一次 localStorage 全量序列化（原先每 id 两次）。
- **profile 页 `useMemo` 化**：单词分类/搜索不再每次渲染全量重建；复用 store 的 `getWordLengthCategory` 消除重复实现。
- **`getRandomWords` 维护累计权重**：去掉每次迭代的 `reduce`。

### 工程 / 测试
- 提取 `parseTranslation`、`normalizeForComparison` 为 lib 纯函数。
- 引入 vitest，新增 25 个单测覆盖熟练度算法、日期处理、翻译解析、句意判等。
- CI（`web.yml`）新增 Test 步骤。
- `.env.example` 补充 `PROD_USER_UID`。
- 同步更新根/子 `AGENTS.md`。

## 验证

- `bun run lint` ✅
- `bun x tsc --noEmit` ✅
- `bun run test`（25 passed）✅
- `bun run build` ✅