### PR TITLE
perf(web): Upstash 全局限流、同步丢弃提示、造句熟练度与 turbo 缓存修复

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -12,5 +12,10 @@ DEEPSEEK_API_KEY=
 DEEPSEEK_BASE_URL=https://api.deepseek.com
 DEEPSEEK_MODEL=deepseek-v4-flash
 
+# Upstash Redis 限流（仅服务端，可选；不配置时回退到进程内限流）
+# Vercel Marketplace 安装 Upstash for Redis 后自动注入 KV_REST_API_* 变量
+KV_REST_API_URL=
+KV_REST_API_TOKEN=
+
 # sync-preview-words 脚本使用：生产用户 UID（仅本地/CI 运行脚本时需要）
 PROD_USER_UID=

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -14,10 +14,11 @@
 
 - 造句/批改功能通过服务端 Route Handler（`src/app/api/sentence/*`）代理调用 DeepSeek，浏览器只请求本站 `/api/*`。
 - `/api/*` 要求请求头携带 Firebase ID token（`Authorization: Bearer <token>`），由 `src/lib/serverAuth.ts` 通过 Identity Toolkit REST API 校验；校验通过返回 `{ uid }`，失败返回 401 的 NextResponse（用 `instanceof NextResponse` 区分）。
-- `/api/*` 按 uid 做进程内固定窗口限流（`src/lib/rateLimit.ts`），超限返回 429；新增 API 路由时应加上限流与输入长度上限。
+- `/api/*` 按 uid 限流（`src/lib/rateLimit.ts`），超限返回 429：配置了 `KV_REST_API_URL`/`KV_REST_API_TOKEN`（或 `UPSTASH_REDIS_REST_*`，Vercel Marketplace 装 Upstash Redis 后自动注入）时用 Upstash 全局限流；未配置或 Upstash 请求失败时回退进程内固定窗口限流（本地开发用）。`checkRateLimit` 是 async，调用时必须 await；新增 API 路由时应加上限流与输入长度上限。
 - DeepSeek 封装位于 `src/lib/deepseek.ts`，读取环境变量 `DEEPSEEK_API_KEY`、`DEEPSEEK_BASE_URL`、`DEEPSEEK_MODEL`。
 - API Key 只允许在服务端使用，禁止加 `NEXT_PUBLIC_` 前缀或下发到前端。
-- 造句练习复用 `useFirestoreWords` 的单词库与 `recordCorrectAttempt`/`recordIncorrectAttempt`，练习结果计入单词熟练度并同步到 Firebase。
+- 造句练习复用 `useFirestoreWords` 的单词库与 `recordCorrectAttempt`/`recordIncorrectAttempt`，练习结果计入单词熟练度并同步到 Firebase；造句场景没有真实输入计时，`recordCorrectAttempt(word)` 不传 `inputTimeSeconds`（该参数仅单词拼写练习传入），不要伪造输入时间以免抬高 speedScore。
+- 同步队列（`src/lib/syncQueue.ts`）条目重试达到上限被丢弃时，`incrementRetries` 返回被丢弃条目，`syncToFirestore` 会 toast 提示用户（文案 `sync.dataLost`），不要改回静默丢弃。
 - 造句题目界面不直接显示目标单词（答题后的反馈区才显示），这是有意设计：学生凭中文句子推断用词，因此造句请求会把词库中存的中文译法随目标词一并传给模型，prompt 要求中文译文自然地道、使用参考译法且能让学生反推出目标词；批改时对目标词的同义表达不判错、仅提示。
 - 批改接口在调用模型前先对答案与参考译文做规范化判等（`src/lib/sentenceCompare.ts` 的 `normalizeForComparison`），完全一致直接返回满分，不消耗模型调用。
 - 纯函数测试用 vitest（`bun run test`，配置在 `vitest.config.mts`），核心算法（熟练度、翻译解析、句意判等、日期处理）新增改动时应同步补测试。

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,6 +15,8 @@
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-toast": "^1.2.15",
     "@tailwindcss/postcss": "^4.1.16",
+    "@upstash/ratelimit": "^2.0.8",
+    "@upstash/redis": "^1.38.2",
     "@vercel/analytics": "^2.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/apps/web/src/app/api/sentence/check/route.ts
+++ b/apps/web/src/app/api/sentence/check/route.ts
@@ -29,7 +29,7 @@ export async function POST(request: Request) {
   const auth = await verifyFirebaseIdToken(request);
   if (auth instanceof NextResponse) return auth;
 
-  const rateLimitError = checkRateLimit(
+  const rateLimitError = await checkRateLimit(
     `${auth.uid}:sentence/check`,
     RATE_LIMIT_PER_MINUTE,
     RATE_LIMIT_WINDOW_MS

--- a/apps/web/src/app/api/sentence/generate/route.ts
+++ b/apps/web/src/app/api/sentence/generate/route.ts
@@ -24,7 +24,7 @@ export async function POST(request: Request) {
   const auth = await verifyFirebaseIdToken(request);
   if (auth instanceof NextResponse) return auth;
 
-  const rateLimitError = checkRateLimit(
+  const rateLimitError = await checkRateLimit(
     `${auth.uid}:sentence/generate`,
     RATE_LIMIT_PER_MINUTE,
     RATE_LIMIT_WINDOW_MS

--- a/apps/web/src/app/api/translate/route.ts
+++ b/apps/web/src/app/api/translate/route.ts
@@ -71,7 +71,7 @@ export async function POST(request: Request) {
   const auth = await verifyFirebaseIdToken(request);
   if (auth instanceof NextResponse) return auth;
 
-  const rateLimitError = checkRateLimit(
+  const rateLimitError = await checkRateLimit(
     `${auth.uid}:translate`,
     RATE_LIMIT_PER_MINUTE,
     RATE_LIMIT_WINDOW_MS

--- a/apps/web/src/hooks/useFirestoreWords.tsx
+++ b/apps/web/src/hooks/useFirestoreWords.tsx
@@ -27,6 +27,7 @@ import { db, getEffectiveUserId } from "@/lib/firebase";
 import { useAuth } from "@/hooks/useAuth";
 import { makeAutoObservable } from "mobx";
 import { SyncQueueManager } from "@/lib/syncQueue";
+import { toast } from "@/hooks/useToast";
 import {
   calculateMasteryScore,
   calculatePriority,
@@ -104,14 +105,16 @@ export class Words {
     this.invalidateCaches();
   }
 
-  // Record a correct attempt with input time
-  recordCorrectAttempt(word: string, inputTimeSeconds: number) {
+  // Record a correct attempt; inputTimeSeconds 仅在真实计时场景（单词拼写练习）传入
+  recordCorrectAttempt(word: string, inputTimeSeconds?: number) {
     const data = this.wordData.get(word);
     if (!data) return;
 
     data.totalAttempts += 1;
     data.correctCount += 1;
-    data.inputTimes.push(inputTimeSeconds);
+    if (inputTimeSeconds !== undefined) {
+      data.inputTimes.push(inputTimeSeconds);
+    }
     const now = new Date();
     const today = formatLocalPracticeDate(now);
     if (!data.correctPracticeDates.includes(today)) {
@@ -424,7 +427,7 @@ interface WordsContextValue {
   deleteWord: (word: string) => Promise<void>;
   updateTranslation: (word: string, translation: string) => Promise<void>;
   removeAllWords: () => Promise<void>;
-  recordCorrectAttempt: (word: string, inputTimeSeconds: number) => void;
+  recordCorrectAttempt: (word: string, inputTimeSeconds?: number) => void;
   recordIncorrectAttempt: (word: string) => void;
   syncToFirestore: () => Promise<void>;
   resetPracticeRecords: () => Promise<void>;
@@ -603,7 +606,7 @@ export const WordsProvider: FC<{ children: ReactNode }> = ({ children }) => {
   }, [user]);
 
   const recordCorrectAttempt = useCallback(
-    (word: string, inputTimeSeconds: number) => {
+    (word: string, inputTimeSeconds?: number) => {
       words.recordCorrectAttempt(word, inputTimeSeconds);
 
       const wordId = words.getWordId(word);
@@ -722,7 +725,13 @@ export const WordsProvider: FC<{ children: ReactNode }> = ({ children }) => {
           SyncQueueManager.removeFromQueue(queueItemIds);
         } catch (error) {
           console.error("Failed to sync batch:", error);
-          SyncQueueManager.incrementRetries(queueItemIds);
+          const discarded = SyncQueueManager.incrementRetries(queueItemIds);
+          if (discarded.length > 0) {
+            toast({
+              title: tError("sync.dataLost"),
+              variant: "destructive",
+            });
+          }
         }
       }
 

--- a/apps/web/src/hooks/useSentencePractice.ts
+++ b/apps/web/src/hooks/useSentencePractice.ts
@@ -2,7 +2,6 @@
 
 import { useCallback, useState } from "react";
 import { useFirestoreWords } from "@/hooks/useFirestoreWords";
-import { getExpectedInputTime } from "@/lib/masteryCalculator";
 import { auth } from "@/lib/firebase";
 
 export interface SentenceQuestion {
@@ -131,7 +130,8 @@ export const useSentencePractice = () => {
 
         question.words.forEach((word) => {
           if (result.correct) {
-            recordCorrectAttempt(word, getExpectedInputTime(word.length));
+            // 造句场景没有真实输入计时，不传 inputTimeSeconds，避免伪造时间抬高 speedScore
+            recordCorrectAttempt(word);
           } else {
             recordIncorrectAttempt(word);
           }

--- a/apps/web/src/lib/i18n.ts
+++ b/apps/web/src/lib/i18n.ts
@@ -129,6 +129,7 @@ export const translations = {
     'sync.pending': '个单词待同步',
     'sync.syncing': '同步中...',
     'sync.syncNow': '立即同步',
+    'sync.dataLost': '部分练习记录多次同步失败，已丢失',
     
     // Mastery levels
     'mastery.new': '新单词',
@@ -244,6 +245,7 @@ export const translations = {
     'sync.pending': 'words pending',
     'sync.syncing': 'Syncing...',
     'sync.syncNow': 'Sync Now',
+    'sync.dataLost': 'Some practice records failed to sync repeatedly and were lost',
     
     // Mastery levels
     'mastery.new': 'New',

--- a/apps/web/src/lib/rateLimit.test.ts
+++ b/apps/web/src/lib/rateLimit.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from "vitest";
+import { checkRateLimit, checkInMemoryRateLimit } from "./rateLimit";
+
+const REDIS_ENV_KEYS = [
+  "KV_REST_API_URL",
+  "KV_REST_API_TOKEN",
+  "UPSTASH_REDIS_REST_URL",
+  "UPSTASH_REDIS_REST_TOKEN",
+] as const;
+
+describe("checkInMemoryRateLimit", () => {
+  it("窗口内未超限时不拦截", () => {
+    const key = `test:allow:${Math.random()}`;
+    for (let i = 0; i < 3; i++) {
+      expect(checkInMemoryRateLimit(key, 3, 60_000)).toBeNull();
+    }
+  });
+
+  it("超过限制返回 429", () => {
+    const key = `test:block:${Math.random()}`;
+    expect(checkInMemoryRateLimit(key, 2, 60_000)).toBeNull();
+    expect(checkInMemoryRateLimit(key, 2, 60_000)).toBeNull();
+    const result = checkInMemoryRateLimit(key, 2, 60_000);
+    expect(result?.status).toBe(429);
+  });
+
+  it("窗口过期后重新计数", () => {
+    vi.useFakeTimers();
+    try {
+      const key = `test:window:${Math.random()}`;
+      expect(checkInMemoryRateLimit(key, 1, 1000)).toBeNull();
+      expect(checkInMemoryRateLimit(key, 1, 1000)?.status).toBe(429);
+      vi.advanceTimersByTime(1001);
+      expect(checkInMemoryRateLimit(key, 1, 1000)).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("checkRateLimit", () => {
+  const savedEnv = new Map<string, string | undefined>();
+
+  beforeAll(() => {
+    for (const key of REDIS_ENV_KEYS) {
+      savedEnv.set(key, process.env[key]);
+      delete process.env[key];
+    }
+  });
+
+  afterAll(() => {
+    for (const key of REDIS_ENV_KEYS) {
+      const value = savedEnv.get(key);
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("未配置 Redis 时回退到进程内限流", async () => {
+    const key = `test:fallback:${Math.random()}`;
+    expect(await checkRateLimit(key, 1, 60_000)).toBeNull();
+    const result = await checkRateLimit(key, 1, 60_000);
+    expect(result?.status).toBe(429);
+  });
+});

--- a/apps/web/src/lib/rateLimit.ts
+++ b/apps/web/src/lib/rateLimit.ts
@@ -1,4 +1,6 @@
 import { NextResponse } from "next/server";
+import { Ratelimit } from "@upstash/ratelimit";
+import { Redis } from "@upstash/redis";
 
 interface Bucket {
   count: number;
@@ -14,7 +16,7 @@ function evictExpiredBuckets(now: number) {
   }
 }
 
-export function checkRateLimit(
+export function checkInMemoryRateLimit(
   key: string,
   limit: number,
   windowMs: number
@@ -30,10 +32,71 @@ export function checkRateLimit(
 
   bucket.count += 1;
   if (bucket.count > limit) {
-    return NextResponse.json(
-      { error: "请求过于频繁，请稍后再试" },
-      { status: 429 }
-    );
+    return tooManyRequests();
   }
   return null;
+}
+
+function tooManyRequests(): NextResponse {
+  return NextResponse.json(
+    { error: "请求过于频繁，请稍后再试" },
+    { status: 429 }
+  );
+}
+
+interface RedisConfig {
+  url: string;
+  token: string;
+}
+
+function getRedisConfig(): RedisConfig | null {
+  const url =
+    process.env.KV_REST_API_URL ?? process.env.UPSTASH_REDIS_REST_URL;
+  const token =
+    process.env.KV_REST_API_TOKEN ?? process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) return null;
+  return { url, token };
+}
+
+let redis: Redis | null = null;
+const limiters = new Map<string, Ratelimit>();
+
+function getLimiter(limit: number, windowMs: number): Ratelimit | null {
+  const config = getRedisConfig();
+  if (!config) return null;
+
+  if (!redis) {
+    redis = new Redis(config);
+  }
+
+  const cacheKey = `${limit}:${windowMs}`;
+  let limiter = limiters.get(cacheKey);
+  if (!limiter) {
+    limiter = new Ratelimit({
+      redis,
+      limiter: Ratelimit.fixedWindow(limit, `${windowMs} ms`),
+      prefix: "ratelimit",
+    });
+    limiters.set(cacheKey, limiter);
+  }
+  return limiter;
+}
+
+export async function checkRateLimit(
+  key: string,
+  limit: number,
+  windowMs: number
+): Promise<NextResponse | null> {
+  const limiter = getLimiter(limit, windowMs);
+  if (!limiter) {
+    return checkInMemoryRateLimit(key, limit, windowMs);
+  }
+
+  try {
+    const { success } = await limiter.limit(key);
+    return success ? null : tooManyRequests();
+  } catch (error) {
+    console.error("Upstash rate limit failed, falling back to in-memory:", error);
+    return checkInMemoryRateLimit(key, limit, windowMs);
+  }
 }

--- a/apps/web/src/lib/syncQueue.test.ts
+++ b/apps/web/src/lib/syncQueue.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { SyncQueueManager, type SyncQueueItem } from "./syncQueue";
+
+class LocalStorageMock {
+  private store = new Map<string, string>();
+
+  getItem(key: string) {
+    return this.store.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string) {
+    this.store.set(key, value);
+  }
+
+  removeItem(key: string) {
+    this.store.delete(key);
+  }
+
+  clear() {
+    this.store.clear();
+  }
+}
+
+const localStorageMock = new LocalStorageMock();
+Object.defineProperty(globalThis, "localStorage", { value: localStorageMock });
+
+function makeItem(word: string): SyncQueueItem {
+  SyncQueueManager.addToQueue({
+    type: "attempt",
+    word,
+    wordId: `id-${word}`,
+    data: { correctCount: 1, totalAttempts: 1, inputTimes: [1] },
+  });
+  const queue = SyncQueueManager.getQueue();
+  return queue[queue.length - 1];
+}
+
+describe("SyncQueueManager", () => {
+  beforeEach(() => {
+    localStorageMock.clear();
+  });
+
+  it("addToQueue 追加条目并补全 id/timestamp/retryCount", () => {
+    const item = makeItem("apple");
+    expect(item.word).toBe("apple");
+    expect(item.retryCount).toBe(0);
+    expect(item.id).toBeTruthy();
+    expect(SyncQueueManager.getQueue()).toHaveLength(1);
+  });
+
+  it("removeFromQueue 按 id 移除", () => {
+    const a = makeItem("apple");
+    makeItem("banana");
+    SyncQueueManager.removeFromQueue([a.id]);
+    expect(SyncQueueManager.getQueue().map((item) => item.word)).toEqual([
+      "banana",
+    ]);
+  });
+
+  it("incrementRetries 未达上限时保留并返回空数组", () => {
+    const item = makeItem("apple");
+    const discarded = SyncQueueManager.incrementRetries([item.id]);
+    expect(discarded).toEqual([]);
+    expect(SyncQueueManager.getQueue()[0].retryCount).toBe(1);
+  });
+
+  it("incrementRetries 达到最大重试次数时丢弃并返回被丢弃条目", () => {
+    const item = makeItem("apple");
+    SyncQueueManager.incrementRetries([item.id]);
+    SyncQueueManager.incrementRetries([item.id]);
+    const discarded = SyncQueueManager.incrementRetries([item.id]);
+    expect(discarded).toHaveLength(1);
+    expect(discarded[0].word).toBe("apple");
+    expect(SyncQueueManager.getQueue()).toHaveLength(0);
+  });
+
+  it("incrementRetries 只影响指定 id", () => {
+    const a = makeItem("apple");
+    const b = makeItem("banana");
+    for (let i = 0; i < 3; i++) {
+      SyncQueueManager.incrementRetries([a.id]);
+    }
+    const queue = SyncQueueManager.getQueue();
+    expect(queue).toHaveLength(1);
+    expect(queue[0].id).toBe(b.id);
+    expect(queue[0].retryCount).toBe(0);
+  });
+});

--- a/apps/web/src/lib/syncQueue.ts
+++ b/apps/web/src/lib/syncQueue.ts
@@ -63,9 +63,10 @@ export class SyncQueueManager {
     }
   }
   
-  // 更新重试次数（达到最大重试次数的自动移除）
-  static incrementRetries(ids: string[]): void {
-    if (ids.length === 0) return;
+  // 更新重试次数（达到最大重试次数的自动移除），返回被丢弃的条目
+  static incrementRetries(ids: string[]): SyncQueueItem[] {
+    const discarded: SyncQueueItem[] = [];
+    if (ids.length === 0) return discarded;
     const queue = this.getQueue();
     const idSet = new Set(ids);
     const remaining: SyncQueueItem[] = [];
@@ -73,13 +74,14 @@ export class SyncQueueManager {
       if (idSet.has(item.id)) {
         item.retryCount++;
         if (item.retryCount >= this.MAX_RETRIES) {
-          // 达到最大重试次数，移除
+          discarded.push(item);
           continue;
         }
       }
       remaining.push(item);
     }
     this.saveQueue(remaining);
+    return discarded;
   }
   
   // 清空队列

--- a/bun.lock
+++ b/bun.lock
@@ -17,6 +17,8 @@
         "@radix-ui/react-slot": "^1.2.4",
         "@radix-ui/react-toast": "^1.2.15",
         "@tailwindcss/postcss": "^4.1.16",
+        "@upstash/ratelimit": "^2.0.8",
+        "@upstash/redis": "^1.38.2",
         "@vercel/analytics": "^2.0.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -682,6 +684,12 @@
     "@unrs/resolver-binding-win32-ia32-msvc": ["@unrs/resolver-binding-win32-ia32-msvc@1.11.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ=="],
 
     "@unrs/resolver-binding-win32-x64-msvc": ["@unrs/resolver-binding-win32-x64-msvc@1.11.1", "", { "os": "win32", "cpu": "x64" }, "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g=="],
+
+    "@upstash/core-analytics": ["@upstash/core-analytics@0.0.10", "", { "dependencies": { "@upstash/redis": "^1.28.3" } }, "sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ=="],
+
+    "@upstash/ratelimit": ["@upstash/ratelimit@2.0.8", "", { "dependencies": { "@upstash/core-analytics": "^0.0.10" }, "peerDependencies": { "@upstash/redis": "^1.34.3" } }, "sha512-YSTMBJ1YIxsoPkUMX/P4DDks/xV5YYCswWMamU8ZIfK9ly6ppjRnVOyBhMDXBmzjODm4UQKcxsJPvaeFAijp5w=="],
+
+    "@upstash/redis": ["@upstash/redis@1.38.2", "", { "dependencies": { "uncrypto": "^0.1.3" } }, "sha512-RZ+JaRCVIS+ZTGnjOnDMr+/0aqDxsBb5rV6aW+Pys4SGELwr5lwE3UbLHRCHqMQ5Ulxj0b/CFBHfbmE175Otog=="],
 
     "@vercel/analytics": ["@vercel/analytics@2.0.1", "", { "peerDependencies": { "@remix-run/react": "^2", "@sveltejs/kit": "^1 || ^2", "next": ">= 13", "nuxt": ">= 3", "react": "^18 || ^19 || ^19.0.0-rc", "svelte": ">= 4", "vue": "^3", "vue-router": "^4" }, "optionalPeers": ["@remix-run/react", "@sveltejs/kit", "next", "nuxt", "react", "svelte", "vue", "vue-router"] }, "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g=="],
 
@@ -1764,6 +1772,8 @@
     "uid-promise": ["uid-promise@1.0.0", "", {}, "sha512-R8375j0qwXyIu/7R0tjdF06/sElHqbmdmWC9M2qQHpEVbvE4I5+38KJI7LUUmQMp7NVq4tKHiBMkT0NFM453Ig=="],
 
     "unbox-primitive": ["unbox-primitive@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "has-bigints": "^1.0.2", "has-symbols": "^1.1.0", "which-boxed-primitive": "^1.1.1" } }, "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw=="],
+
+    "uncrypto": ["uncrypto@0.1.3", "", {}, "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="],
 
     "undici": ["undici@5.29.0", "", { "dependencies": { "@fastify/busboy": "^2.0.0" } }, "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg=="],
 

--- a/turbo.json
+++ b/turbo.json
@@ -7,8 +7,17 @@
       "persistent": true
     },
     "build": {
-      "env": ["NEXT_PUBLIC_FIREBASE_*"],
+      "env": [
+        "NEXT_PUBLIC_FIREBASE_*",
+        "NEXT_PUBLIC_VERCEL_ENV",
+        "KV_REST_API_URL",
+        "KV_REST_API_TOKEN",
+        "UPSTASH_REDIS_REST_URL",
+        "UPSTASH_REDIS_REST_TOKEN"
+      ],
       "outputs": ["dist/**", ".next/**"]
-    }
+    },
+    "lint": {},
+    "test": {}
   }
 }


### PR DESCRIPTION
## 改动内容

### 1. Upstash 全局限流
- 原进程内固定窗口限流在 Vercel serverless 下每个实例独立计数，限流阈值被实例数放大
- `checkRateLimit` 改为 async：配置了 `KV_REST_API_*` / `UPSTASH_REDIS_*`（Vercel Marketplace 装 Upstash Redis 后自动注入）时走 Upstash 全局限流；未配置或 Upstash 故障时回退进程内限流，本地开发零配置
- 三个 API 路由（translate、sentence/generate、sentence/check）同步改为 await

### 2. 同步队列丢弃提示
- 原来队列条目重试 3 次失败后被静默丢弃，用户练习数据丢失无感知
- `incrementRetries` 返回被丢弃条目，`syncToFirestore` 检测到后 toast 提示（新增中英双语文案 `sync.dataLost`）

### 3. 造句练习熟练度污染修复
- 原来造句批改正确时用 `getExpectedInputTime` 伪造输入时间，抬高 speedScore
- `recordCorrectAttempt` 的 `inputTimeSeconds` 改为可选，造句场景不传，不再污染速度评分

### 4. turbo 缓存修复
- 新增 `lint`/`test` task，可缓存
- `build` env 白名单补 `NEXT_PUBLIC_VERCEL_ENV` 和 Redis 变量，避免 preview/production 产物互相污染缓存

### 测试
- 新增 `rateLimit.test.ts`（4 个）、`syncQueue.test.ts`（5 个）
- 全部 34 个测试、lint、tsc、生产构建通过

## 部署后操作
- 已在 Vercel Marketplace 安装 Upstash for Redis，环境变量已注入
- 合并后触发重新部署即生效