### PR TITLE
feat(web): 添加单词支持多义项，删除双击编辑翻译

### DIFF
--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -27,7 +27,7 @@
 - `/api/*` 要求请求头携带 Firebase ID token（`Authorization: Bearer <token>`），由 `src/lib/serverAuth.ts` 通过 Identity Toolkit REST API 校验；校验通过返回 `{ uid }`，失败返回 401 的 NextResponse（用 `instanceof NextResponse` 区分）。
 - `/api/*` 按 uid 限流（`src/lib/rateLimit.ts`），超限返回 429：配置了 `KV_REST_API_URL`/`KV_REST_API_TOKEN`（或 `UPSTASH_REDIS_REST_*`，Vercel Marketplace 装 Upstash Redis 后自动注入）时用 Upstash 全局限流；未配置或 Upstash 请求失败时回退进程内固定窗口限流（本地开发用）。`checkRateLimit` 是 async，调用时必须 await；新增 API 路由时应加上限流与输入长度上限。
 - DeepSeek 封装位于 `src/lib/deepseek.ts`，读取环境变量 `DEEPSEEK_API_KEY`、`DEEPSEEK_BASE_URL`、`DEEPSEEK_MODEL`；`chatCompletionJson` 支持可选 `temperature`（默认 0.7）。
-- `/api/translate` 的英文释义与中文译法由 DeepSeek 一次调用生成，不再使用 Google Translate/Datamuse 等外部免费源或回退词典（`lib/dictionary.ts` 已删除）；模型判定非有效单词时返回两字段 null（前端提示未识别），调用失败时返回错误且前端不落库；内存 LRU 缓存只存两字段非空的成功结果。
+- `/api/translate` 由 DeepSeek 一次调用生成结构化义项数组 `senses: [{ pos, chinese, english }]`（2~4 个义项，最常用在前），不再使用 Google Translate/Datamuse 等外部免费源或回退词典（`lib/dictionary.ts` 已删除）；模型判定非有效单词时返回 `senses: null`（前端提示未识别），调用失败时返回错误且前端不落库；内存 LRU 缓存只存 `senses` 非空数组的成功结果。前端用 `src/lib/parseTranslation.ts` 的 `formatSenses` 把 `senses` 拼成「每义项一行（词性+中文 — 英文）」存入 `translation` 字段，`parseTranslation` 兼容旧格式（首行英文、其余中文）。
 - API Key 只允许在服务端使用，禁止加 `NEXT_PUBLIC_` 前缀或下发到前端。
 - 造句练习复用 `useFirestoreWords` 的单词库与 `recordCorrectAttempt`/`recordIncorrectAttempt`，练习结果计入单词熟练度并同步到 Firebase；造句场景没有真实输入计时，`recordCorrectAttempt(word)` 不传 `inputTimeSeconds`（该参数仅单词拼写练习传入），不要伪造输入时间以免抬高 speedScore。
 - 批改接口返回 `usedWords`（用户实际用到的目标词，同义表达替代也算），客户端只对 `usedWords` 中的词调用 `recordCorrect/IncorrectAttempt`，未用到的目标词不记分；模型未返回该字段时回退为全部目标词。

--- a/apps/web/src/app/add-word/page.tsx
+++ b/apps/web/src/app/add-word/page.tsx
@@ -5,11 +5,11 @@ import { useRef, useState } from "react";
 import Link from "next/link";
 import { useFirestoreWords, useLocale, toast } from "@/hooks";
 import { auth } from "@/lib/firebase";
+import { formatSenses, type WordSense } from "@/lib/parseTranslation";
 
 interface PendingWord {
   word: string;
-  englishDefinition: string;
-  chineseTranslation: string;
+  senses: WordSense[];
 }
 
 const Home = () => {
@@ -31,9 +31,7 @@ const Home = () => {
     if (!pending) return;
 
     setConfirming(true);
-    const combinedTranslation = pending.chineseTranslation
-      ? `${pending.englishDefinition}\n${pending.chineseTranslation}`
-      : pending.englishDefinition;
+    const combinedTranslation = formatSenses(pending.senses);
 
     try {
       await addWord(pending.word, combinedTranslation);
@@ -87,12 +85,11 @@ const Home = () => {
         throw new Error(data && typeof data.error === 'string' ? data.error : t('addWord.addFailed'));
       }
 
-      const { chineseTranslation, englishDefinition } = data as {
-        chineseTranslation: string | null;
-        englishDefinition: string | null;
+      const { senses } = data as {
+        senses: WordSense[] | null;
       };
 
-      if (!englishDefinition) {
+      if (!senses || senses.length === 0) {
         toast({ title: t('addWord.notRecognized').replace('{word}', word), variant: "destructive" });
         clear();
         setLoading(false);
@@ -101,8 +98,7 @@ const Home = () => {
 
       setPending({
         word,
-        englishDefinition,
-        chineseTranslation: chineseTranslation || "",
+        senses,
       });
       setDialogOpen(true);
     } catch (error) {
@@ -164,12 +160,8 @@ const Home = () => {
           {pending && (
             <div className="space-y-3">
               <div>
-                <div className="text-sm font-medium">{t('addWord.confirmEnglish')}</div>
-                <div className="text-sm text-muted-foreground">{pending.englishDefinition}</div>
-              </div>
-              <div>
-                <div className="text-sm font-medium">{t('addWord.confirmChinese')}</div>
-                <div className="text-sm text-muted-foreground">{pending.chineseTranslation}</div>
+                <div className="text-sm font-medium">{t('addWord.confirmSenses')}</div>
+                <div className="text-sm text-muted-foreground whitespace-pre-line">{formatSenses(pending.senses)}</div>
               </div>
             </div>
           )}

--- a/apps/web/src/app/api/sentence/generate/route.ts
+++ b/apps/web/src/app/api/sentence/generate/route.ts
@@ -15,7 +15,7 @@ interface GenerateResult {
 const MAX_WORDS = 3;
 const MIN_WORDS = 1;
 const MAX_WORD_LENGTH = 50;
-const MAX_TRANSLATION_LENGTH = 200;
+const MAX_TRANSLATION_LENGTH = 2000;
 const RATE_LIMIT_PER_MINUTE = 10;
 const RATE_LIMIT_WINDOW_MS = 60 * 1000;
 

--- a/apps/web/src/app/api/translate/route.ts
+++ b/apps/web/src/app/api/translate/route.ts
@@ -8,18 +8,24 @@ const MAX_WORD_LENGTH = 50;
 const RATE_LIMIT_PER_MINUTE = 30;
 const RATE_LIMIT_WINDOW_MS = 60 * 1000;
 const MAX_CACHE_ENTRIES = 1000;
-const MAX_DEFINITION_LENGTH = 200;
-const MAX_TRANSLATION_LENGTH = 200;
+const MAX_SENSES = 4;
+const MAX_POS_LENGTH = 10;
+const MAX_DEFINITION_LENGTH = 150;
+const MAX_TRANSLATION_LENGTH = 50;
+
+interface WordSense {
+  pos: string;
+  chinese: string;
+  english: string;
+}
 
 interface TranslationCacheEntry {
-  chineseTranslation: string | null;
-  englishDefinition: string | null;
+  senses: WordSense[] | null;
 }
 
 interface WordLookupResult {
   isWord: boolean;
-  englishDefinition: string;
-  chineseTranslation: string;
+  senses: WordSense[];
 }
 
 const translationCache = new Map<string, TranslationCacheEntry>();
@@ -34,11 +40,7 @@ function getCached(word: string): TranslationCacheEntry | undefined {
 }
 
 function setCached(word: string, entry: TranslationCacheEntry): void {
-  if (
-    !entry.chineseTranslation ||
-    !entry.englishDefinition ||
-    translationCache.has(word)
-  ) {
+  if (!entry.senses || entry.senses.length === 0 || translationCache.has(word)) {
     return;
   }
   if (translationCache.size >= MAX_CACHE_ENTRIES) {
@@ -55,11 +57,13 @@ async function lookupWord(word: string): Promise<TranslationCacheEntry> {
         role: "system",
         content: [
           "你是一位英语词典编辑。用户会给出一个英文单词。",
-          "如果它是真实存在的英文单词，isWord 为 true，并返回：",
-          "1. englishDefinition：最常见义项的简短英文释义，学习型词典风格，一句话，不超过 20 个单词；",
-          "2. chineseTranslation：该义项最常用的中文译法，简洁（不超过 6 个字，有多个常用译法时用顿号分隔）。",
-          "如果不是有效英文单词（拼写错误或生造词），isWord 为 false，两个字段均为空字符串。",
-          '只返回 JSON，不要添加其它字段或解释：{"isWord": true|false, "englishDefinition": "...", "chineseTranslation": "..."}',
+          "如果它是真实存在的英文单词，isWord 为 true，并返回 senses 数组：按词性/义项列出该词最常见到较常见的多个义项（通常 2-4 个），最常用的义项排在最前面。",
+          "每个义项包含：",
+          "1. pos：简短词性标注（如 n.、v.、adj.、adv. 等）；",
+          "2. chinese：该义项最常用的中文译法，简洁（不超过 10 个字，有多个常用译法时用顿号分隔）；",
+          "3. english：该义项的学习型词典风格简短英文释义，一句话，不超过 15 个单词。",
+          "如果不是有效英文单词（拼写错误或生造词），isWord 为 false，senses 为空数组。",
+          '只返回 JSON，不要添加其它字段或解释：{"isWord": true|false, "senses": [{"pos": "...", "chinese": "...", "english": "..."}]}',
         ].join("\n"),
       },
       { role: "user", content: word },
@@ -68,28 +72,33 @@ async function lookupWord(word: string): Promise<TranslationCacheEntry> {
   );
 
   if (!result?.isWord) {
-    return { chineseTranslation: null, englishDefinition: null };
+    return { senses: null };
   }
 
-  const englishDefinition =
-    typeof result.englishDefinition === "string"
-      ? result.englishDefinition.trim()
-      : "";
-  const chineseTranslation =
-    typeof result.chineseTranslation === "string"
-      ? result.chineseTranslation.trim()
-      : "";
+  const senses = Array.isArray(result.senses)
+    ? result.senses
+        .slice(0, MAX_SENSES)
+        .map((sense) => ({
+          pos: typeof sense?.pos === "string" ? sense.pos.trim() : "",
+          chinese: typeof sense?.chinese === "string" ? sense.chinese.trim() : "",
+          english: typeof sense?.english === "string" ? sense.english.trim() : "",
+        }))
+        .filter(
+          (sense) =>
+            sense.pos &&
+            sense.pos.length <= MAX_POS_LENGTH &&
+            sense.chinese &&
+            sense.chinese.length <= MAX_TRANSLATION_LENGTH &&
+            sense.english &&
+            sense.english.length <= MAX_DEFINITION_LENGTH
+        )
+    : [];
 
-  if (
-    !englishDefinition ||
-    englishDefinition.length > MAX_DEFINITION_LENGTH ||
-    !chineseTranslation ||
-    chineseTranslation.length > MAX_TRANSLATION_LENGTH
-  ) {
+  if (senses.length === 0) {
     throw new DeepSeekError("AI 服务返回内容异常", 502);
   }
 
-  return { chineseTranslation, englishDefinition };
+  return { senses };
 }
 
 export async function POST(request: Request) {

--- a/apps/web/src/app/words/page.tsx
+++ b/apps/web/src/app/words/page.tsx
@@ -5,7 +5,7 @@ import { useCallback, useEffect, useState, useRef, type FormEvent, type RefObjec
 import { observer } from "mobx-react-lite";
 import Link from "next/link";
 import { useFirestoreWords, useLocale } from "@/hooks";
-import { formatSenses, parseTranslation } from "@/lib/parseTranslation";
+import { parseTranslation } from "@/lib/parseTranslation";
 import type { Words } from "@/lib/wordsStore";
 import type { TranslationKey } from "@/lib/i18n";
 
@@ -28,9 +28,18 @@ const WordRow = observer(({ word, translation, words, onInputChange, onHintRevea
     <li className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-x-2 gap-y-1">
       <div className="max-w-xs w-full text-right justify-self-end">
         <div
-          className={`min-h-9 px-3 py-1 flex items-center justify-end whitespace-pre-line ${hasSense ? "font-semibold" : "text-gray-400 italic"}`}
+          className={`min-h-9 px-3 py-1 flex flex-col items-end justify-center whitespace-pre-line ${hasSense ? "font-semibold" : "text-gray-400 italic"}`}
         >
-          {hasSense ? formatSenses(senses) : t("home.noTranslation")}
+          {hasSense ? (
+            senses.map((sense, index) => (
+              <span key={index}>
+                {[sense.pos, sense.chinese].filter(Boolean).join(" ")}
+                {sense.english && <span className="text-sm font-normal text-gray-500"> — {sense.english}</span>}
+              </span>
+            ))
+          ) : (
+            t("home.noTranslation")
+          )}
         </div>
       </div>
       <div className="flex items-center space-x-2">

--- a/apps/web/src/app/words/page.tsx
+++ b/apps/web/src/app/words/page.tsx
@@ -25,10 +25,10 @@ const WordRow = observer(({ word, translation, words, onInputChange, onHintRevea
   const hasSense = senses.some((sense) => sense.chinese);
 
   return (
-    <li className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-x-2 gap-y-1">
+    <li className="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-x-2 gap-y-1">
       <div className="max-w-xs w-full text-right justify-self-end">
         <div
-          className={`min-h-9 px-3 py-1 flex flex-col items-end justify-center whitespace-pre-line ${hasSense ? "font-semibold" : "text-gray-400 italic"}`}
+          className={`min-h-9 px-3 py-1 flex flex-col items-end justify-start whitespace-pre-line ${hasSense ? "font-semibold" : "text-gray-400 italic"}`}
         >
           {hasSense ? (
             senses.map((sense, index) => (

--- a/apps/web/src/app/words/page.tsx
+++ b/apps/web/src/app/words/page.tsx
@@ -4,8 +4,8 @@ import { Input, Button, MasteryBar, SyncIndicator } from "@/components/ui";
 import { useCallback, useEffect, useState, useRef, type FormEvent, type RefObject } from "react";
 import { observer } from "mobx-react-lite";
 import Link from "next/link";
-import { useFirestoreWords, useLocale, toast } from "@/hooks";
-import { parseTranslation } from "@/lib/parseTranslation";
+import { useFirestoreWords, useLocale } from "@/hooks";
+import { formatSenses, parseTranslation } from "@/lib/parseTranslation";
 import type { Words } from "@/lib/wordsStore";
 import type { TranslationKey } from "@/lib/i18n";
 
@@ -13,65 +13,25 @@ interface WordRowProps {
   word: string;
   translation: string;
   words: Words;
-  isEditing: boolean;
-  editingValue: string;
-  onEditingValueChange: (value: string) => void;
-  onStartEdit: (word: string, englishDefinition: string, chineseTranslation: string) => void;
-  onCommitEdit: () => void;
-  onCancelEdit: () => void;
   onInputChange: (word: string, value: string) => void;
   onHintReveal: (word: string) => void;
   inputRefs: RefObject<Map<string, HTMLInputElement>>;
   t: (key: TranslationKey) => string;
 }
 
-const WordRow = observer(({ word, translation, words, isEditing, editingValue, onEditingValueChange, onStartEdit, onCommitEdit, onCancelEdit, onInputChange, onHintReveal, inputRefs, t }: WordRowProps) => {
+const WordRow = observer(({ word, translation, words, onInputChange, onHintReveal, inputRefs, t }: WordRowProps) => {
   const inputValue = words.userInputs.get(word) || "";
-  const { englishDefinition, chineseTranslation } = parseTranslation(translation);
+  const { senses } = parseTranslation(translation);
+  const hasSense = senses.some((sense) => sense.chinese);
 
   return (
     <li className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-x-2 gap-y-1">
       <div className="max-w-xs w-full text-right justify-self-end">
-        {isEditing ? (
-          <Input
-            className="w-full text-right"
-            type="text"
-            value={editingValue}
-            autoFocus
-            onChange={(e) => onEditingValueChange(e.target.value)}
-            onBlur={() => {
-              onCommitEdit();
-            }}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") {
-                if (e.nativeEvent.isComposing) {
-                  return;
-                }
-                e.preventDefault();
-                onCommitEdit();
-              }
-
-              if (e.key === "Escape") {
-                e.preventDefault();
-                onCancelEdit();
-              }
-            }}
-          />
-        ) : (
-          <div
-            className={`h-9 px-3 py-1 flex items-center justify-end whitespace-pre-line ${chineseTranslation ? "font-semibold" : "text-gray-400 italic"} cursor-pointer focus:outline-none focus:ring-2 focus:ring-blue-500 focus:rounded`}
-            onDoubleClick={() => onStartEdit(word, englishDefinition, chineseTranslation)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" || e.key === " ") {
-                e.preventDefault();
-                onStartEdit(word, englishDefinition, chineseTranslation);
-              }
-            }}
-            title={t("home.editTranslationHint")}
-          >
-            {chineseTranslation || t("home.addChineseTranslation")}
-          </div>
-        )}
+        <div
+          className={`min-h-9 px-3 py-1 flex items-center justify-end whitespace-pre-line ${hasSense ? "font-semibold" : "text-gray-400 italic"}`}
+        >
+          {hasSense ? formatSenses(senses) : t("home.noTranslation")}
+        </div>
       </div>
       <div className="flex items-center space-x-2">
         <Input
@@ -116,8 +76,6 @@ const WordRow = observer(({ word, translation, words, isEditing, editingValue, o
         </button>
         <MasteryBar score={words.getMasteryScore(word)} />
       </div>
-      {englishDefinition && <div className="max-w-xs w-full text-right text-sm text-gray-500 whitespace-pre-line justify-self-end">{englishDefinition}</div>}
-      {englishDefinition && <div />}
     </li>
   );
 });
@@ -132,27 +90,14 @@ const SubmitButton = observer(({ randomWords, words, label }: { randomWords: [st
 });
 
 const WordsPractice = observer(() => {
-  const { words, recordCorrectAttempt, recordIncorrectAttempt, syncToFirestore, syncing, pendingCount, loading, error, updateTranslation } = useFirestoreWords();
+  const { words, recordCorrectAttempt, recordIncorrectAttempt, syncToFirestore, syncing, pendingCount, loading, error } = useFirestoreWords();
   const { t } = useLocale();
   const [isClient, setIsClient] = useState(false);
   const [shouldFocusFirst, setShouldFocusFirst] = useState(false);
   const [randomWords, setRandomWords] = useState<[string, string][]>([]);
-  const [editingWord, setEditingWord] = useState<string | null>(null);
-  const [editingValue, setEditingValue] = useState("");
   const inputRefs = useRef<Map<string, HTMLInputElement>>(new Map());
   const incorrectRecordedRef = useRef<Set<string>>(new Set());
   const timerStartRef = useRef<Map<string, number>>(new Map());
-  const editSessionRef = useRef<{
-    word: string | null;
-    originalChinese: string;
-    englishDefinition: string;
-    committed: boolean;
-  }>({
-    word: null,
-    originalChinese: "",
-    englishDefinition: "",
-    committed: false,
-  });
 
   useEffect(() => {
     setIsClient(true);
@@ -186,69 +131,6 @@ const WordsPractice = observer(() => {
     setRandomWords(words.getRandomWords());
     setShouldFocusFirst(true);
   };
-
-  const startEditingTranslation = useCallback((word: string, englishDefinition: string, chineseTranslation: string) => {
-    setEditingWord(word);
-    setEditingValue(chineseTranslation);
-    editSessionRef.current = {
-      word,
-      originalChinese: chineseTranslation,
-      englishDefinition,
-      committed: false,
-    };
-  }, []);
-
-  const cancelEditingTranslation = useCallback(() => {
-    setEditingWord(null);
-    setEditingValue("");
-    editSessionRef.current = {
-      word: null,
-      originalChinese: "",
-      englishDefinition: "",
-      committed: false,
-    };
-  }, []);
-
-  const commitEditingTranslation = useCallback(async () => {
-    const session = editSessionRef.current;
-    if (!session.word || session.committed) {
-      return;
-    }
-
-    const trimmed = editingValue.trim();
-    if (!trimmed) {
-      toast({
-        title: t("home.translationEmpty"),
-        variant: "destructive",
-      });
-      return;
-    }
-
-    if (trimmed === session.originalChinese) {
-      cancelEditingTranslation();
-      return;
-    }
-
-    session.committed = true;
-
-    try {
-      const newTranslation = session.englishDefinition ? `${session.englishDefinition}\n${trimmed}` : trimmed;
-      await updateTranslation(session.word, newTranslation);
-      setRandomWords((prev) => prev.map(([itemWord, itemTranslation]) => (itemWord === session.word ? [itemWord, newTranslation] : [itemWord, itemTranslation])));
-      toast({
-        title: t("home.translationUpdated"),
-        variant: "success",
-      });
-      cancelEditingTranslation();
-    } catch (err) {
-      console.error("Failed to update translation:", err);
-      session.committed = false;
-      toast({
-        title: t("home.translationUpdateFailed"),
-        variant: "destructive",
-      });
-    }
-  }, [editingValue, t, updateTranslation, cancelEditingTranslation]);
 
   const handleInputChange = useCallback((word: string, value: string) => {
     // Start timer on first character typed
@@ -334,12 +216,6 @@ const WordsPractice = observer(() => {
                   word={word}
                   translation={translation}
                   words={words}
-                  isEditing={editingWord === word}
-                  editingValue={editingWord === word ? editingValue : ""}
-                  onEditingValueChange={setEditingValue}
-                  onStartEdit={startEditingTranslation}
-                  onCommitEdit={commitEditingTranslation}
-                  onCancelEdit={cancelEditingTranslation}
                   onInputChange={handleInputChange}
                   onHintReveal={handleHintReveal}
                   inputRefs={inputRefs}

--- a/apps/web/src/hooks/useFirestoreWords.tsx
+++ b/apps/web/src/hooks/useFirestoreWords.tsx
@@ -18,7 +18,6 @@ import {
   doc,
   onSnapshot,
   getDocs,
-  updateDoc,
   writeBatch,
   type WriteBatch,
 } from "firebase/firestore";
@@ -55,7 +54,6 @@ interface WordsContextValue {
   words: Words;
   addWord: (word: string, translation: string) => Promise<void>;
   deleteWord: (word: string) => Promise<void>;
-  updateTranslation: (word: string, translation: string) => Promise<void>;
   removeAllWords: () => Promise<void>;
   recordCorrectAttempt: (word: string, inputTimeSeconds?: number) => void;
   recordIncorrectAttempt: (word: string) => void;
@@ -184,33 +182,6 @@ export const WordsProvider: FC<{ children: ReactNode }> = ({ children }) => {
       } catch (err) {
         console.error("Failed to delete word:", err);
         throw new Error(tError("error.deleteWordFailed"));
-      }
-    },
-    [user]
-  );
-
-  const updateTranslation = useCallback(
-    async (word: string, translation: string) => {
-      if (!user) {
-        throw new Error(tError("error.notAuthenticated"));
-      }
-
-      const wordId = words.getWordId(word);
-      if (!wordId) {
-        throw new Error(tError("error.wordNotFound"));
-      }
-
-      try {
-        const userId = getEffectiveUserId(user);
-        const wordDocRef = doc(db, "users", userId, "words", wordId);
-        await updateDoc(wordDocRef, {
-          translation,
-        });
-
-        words.updateTranslation(word, translation);
-      } catch (err) {
-        console.error("Failed to update translation:", err);
-        throw new Error(tError("error.updateTranslationFailed"));
       }
     },
     [user]
@@ -455,7 +426,6 @@ export const WordsProvider: FC<{ children: ReactNode }> = ({ children }) => {
       words,
       addWord,
       deleteWord,
-      updateTranslation,
       removeAllWords,
       recordCorrectAttempt,
       recordIncorrectAttempt,
@@ -469,7 +439,6 @@ export const WordsProvider: FC<{ children: ReactNode }> = ({ children }) => {
     [
       addWord,
       deleteWord,
-      updateTranslation,
       removeAllWords,
       recordCorrectAttempt,
       recordIncorrectAttempt,

--- a/apps/web/src/lib/i18n.ts
+++ b/apps/web/src/lib/i18n.ts
@@ -48,16 +48,11 @@ export const translations = {
     'error.removeWordsFailed': '从云端删除单词失败',
     'error.resetFailed': '重置练习记录失败',
     'error.wordNotFound': '未找到单词',
-    'error.updateTranslationFailed': '更新翻译失败',
     
     // Home page
     'home.refresh': '刷新单词',
     'home.hint': '提示',
-    'home.editTranslationHint': '双击编辑中文翻译',
-    'home.addChineseTranslation': '双击添加中文翻译',
-    'home.translationUpdated': '中文翻译已更新',
-    'home.translationEmpty': '中文翻译不能为空',
-    'home.translationUpdateFailed': '更新翻译失败，请重试',
+    'home.noTranslation': '暂无中文翻译',
 
     // Sentence practice
     'sentence.title': '造句练习',
@@ -124,8 +119,7 @@ export const translations = {
     'addWord.notRecognized': '单词 "{word}" 未被识别为有效单词。',
     'addWord.addFailed': '添加单词到云端失败：',
     'addWord.confirmTitle': '确认添加单词',
-    'addWord.confirmEnglish': '英文释义',
-    'addWord.confirmChinese': '中文译法',
+    'addWord.confirmSenses': '词义',
     'addWord.confirmAdd': '确认添加',
     'addWord.cancel': '取消',
 
@@ -168,16 +162,11 @@ export const translations = {
     'error.removeWordsFailed': 'Failed to remove words from cloud',
     'error.resetFailed': 'Failed to reset practice records',
     'error.wordNotFound': 'Word not found',
-    'error.updateTranslationFailed': 'Failed to update translation',
     
     // Home page
     'home.refresh': 'Refresh Words',
     'home.hint': 'Hint',
-    'home.editTranslationHint': 'Double-click to edit Chinese translation',
-    'home.addChineseTranslation': 'Double-click to add Chinese translation',
-    'home.translationUpdated': 'Chinese translation updated',
-    'home.translationEmpty': 'Chinese translation cannot be empty',
-    'home.translationUpdateFailed': 'Failed to update translation. Please try again.',
+    'home.noTranslation': 'No Chinese translation',
 
     // Sentence practice
     'sentence.title': 'Sentence Practice',
@@ -244,8 +233,7 @@ export const translations = {
     'addWord.notRecognized': 'The word "{word}" is not recognized as a real word.',
     'addWord.addFailed': 'Failed to add word to cloud: ',
     'addWord.confirmTitle': 'Confirm Word',
-    'addWord.confirmEnglish': 'English Definition',
-    'addWord.confirmChinese': 'Chinese Translation',
+    'addWord.confirmSenses': 'Senses',
     'addWord.confirmAdd': 'Add',
     'addWord.cancel': 'Cancel',
 

--- a/apps/web/src/lib/parseTranslation.test.ts
+++ b/apps/web/src/lib/parseTranslation.test.ts
@@ -1,50 +1,82 @@
 import { describe, it, expect } from "vitest";
-import { parseTranslation } from "./parseTranslation";
+import { parseTranslation, formatSenses } from "./parseTranslation";
 
 describe("parseTranslation", () => {
-  it("空字符串返回空", () => {
-    expect(parseTranslation("")).toEqual({
-      englishDefinition: "",
-      chineseTranslation: "",
+  it("空字符串返回空 senses", () => {
+    expect(parseTranslation("")).toEqual({ senses: [] });
+    expect(parseTranslation("  \n  ")).toEqual({ senses: [] });
+  });
+
+  it("新格式：每行一个义项，解析词性/中文/英文", () => {
+    expect(
+      parseTranslation("v. 吐（口水）；喷出 — to force liquid from the mouth\nn. 口水；唾沫 — liquid in the mouth")
+    ).toEqual({
+      senses: [
+        { pos: "v.", chinese: "吐（口水）；喷出", english: "to force liquid from the mouth" },
+        { pos: "n.", chinese: "口水；唾沫", english: "liquid in the mouth" },
+      ],
     });
-    expect(parseTranslation("  \n  ")).toEqual({
-      englishDefinition: "",
-      chineseTranslation: "",
+  });
+
+  it("旧格式：首行为英文释义，其余为中文翻译", () => {
+    expect(parseTranslation("a round fruit\n苹果")).toEqual({
+      senses: [{ pos: "", chinese: "苹果", english: "a round fruit" }],
+    });
+  });
+
+  it("旧格式：多行中文合并到同一义项", () => {
+    expect(parseTranslation("a round fruit\n苹果\n一种水果")).toEqual({
+      senses: [{ pos: "", chinese: "苹果\n一种水果", english: "a round fruit" }],
     });
   });
 
   it("单行中文作为中文翻译", () => {
     expect(parseTranslation("苹果")).toEqual({
-      englishDefinition: "",
-      chineseTranslation: "苹果",
+      senses: [{ pos: "", chinese: "苹果", english: "" }],
     });
   });
 
   it("单行英文作为英文释义", () => {
     expect(parseTranslation("a round fruit")).toEqual({
-      englishDefinition: "a round fruit",
-      chineseTranslation: "",
-    });
-  });
-
-  it("多行时首行为英文释义，其余为中文翻译", () => {
-    expect(parseTranslation("a round fruit\n苹果")).toEqual({
-      englishDefinition: "a round fruit",
-      chineseTranslation: "苹果",
-    });
-  });
-
-  it("中文翻译多行时合并保留换行", () => {
-    expect(parseTranslation("a round fruit\n苹果\n一种水果")).toEqual({
-      englishDefinition: "a round fruit",
-      chineseTranslation: "苹果\n一种水果",
+      senses: [{ pos: "", chinese: "", english: "a round fruit" }],
     });
   });
 
   it("去除多余空白", () => {
-    expect(parseTranslation("  a round fruit \n 苹果 ")).toEqual({
-      englishDefinition: "a round fruit",
-      chineseTranslation: "苹果",
+    expect(parseTranslation("  v. 吐  — to spit \n 苹果 ")).toEqual({
+      senses: [
+        { pos: "v.", chinese: "吐", english: "to spit" },
+        { pos: "", chinese: "苹果", english: "" },
+      ],
     });
+  });
+});
+
+describe("formatSenses", () => {
+  it("格式化义项数组为每行一个义项", () => {
+    expect(
+      formatSenses([
+        { pos: "v.", chinese: "吐（口水）；喷出", english: "to force liquid from the mouth" },
+        { pos: "n.", chinese: "口水；唾沫", english: "liquid in the mouth" },
+      ])
+    ).toBe("v. 吐（口水）；喷出 — to force liquid from the mouth\nn. 口水；唾沫 — liquid in the mouth");
+  });
+
+  it("空词性/空英文时省略对应部分", () => {
+    expect(formatSenses([{ pos: "", chinese: "苹果", english: "a round fruit" }])).toBe("苹果 — a round fruit");
+    expect(formatSenses([{ pos: "", chinese: "苹果", english: "" }])).toBe("苹果");
+    expect(formatSenses([{ pos: "", chinese: "", english: "a round fruit" }])).toBe("a round fruit");
+  });
+
+  it("空数组返回空字符串", () => {
+    expect(formatSenses([])).toBe("");
+  });
+
+  it("formatSenses 输出可被 parseTranslation 往返解析", () => {
+    const senses = [
+      { pos: "v.", chinese: "吐（口水）；喷出", english: "to force liquid from the mouth" },
+      { pos: "n.", chinese: "口水；唾沫", english: "liquid in the mouth" },
+    ];
+    expect(parseTranslation(formatSenses(senses))).toEqual({ senses });
   });
 });

--- a/apps/web/src/lib/parseTranslation.ts
+++ b/apps/web/src/lib/parseTranslation.ts
@@ -1,28 +1,62 @@
-export interface ParsedTranslation {
-  englishDefinition: string;
-  chineseTranslation: string;
+export interface WordSense {
+  pos: string;
+  chinese: string;
+  english: string;
 }
 
+export interface ParsedTranslation {
+  senses: WordSense[];
+}
+
+const SENSE_LINE_PATTERN = /^([a-zA-Z]+\.)\s+(.+?)\s*—\s*(.+)$/;
+
 export const parseTranslation = (translation: string): ParsedTranslation => {
-  const segments = translation
+  const lines = translation
     .split("\n")
-    .map((segment) => segment.trim())
+    .map((line) => line.trim())
     .filter(Boolean);
 
-  if (segments.length === 0) {
-    return { englishDefinition: "", chineseTranslation: "" };
+  if (lines.length === 0) {
+    return { senses: [] };
   }
 
-  if (segments.length === 1) {
-    const single = segments[0];
-    const hasChinese = /[\u4e00-\u9fff]/.test(single);
-    return hasChinese
-      ? { englishDefinition: "", chineseTranslation: single }
-      : { englishDefinition: single, chineseTranslation: "" };
+  const senses: WordSense[] = [];
+  let legacyEnglish: string | null = null;
+
+  for (const line of lines) {
+    const match = SENSE_LINE_PATTERN.exec(line);
+    if (match) {
+      senses.push({ pos: match[1], chinese: match[2], english: match[3] });
+    } else if (/[\u4e00-\u9fff]/.test(line)) {
+      const last = senses[senses.length - 1];
+      if (last && last.chinese && !last.pos && !last.english) {
+        last.chinese = `${last.chinese}\n${line}`;
+      } else {
+        senses.push({ pos: "", chinese: line, english: "" });
+      }
+    } else {
+      legacyEnglish = line;
+    }
   }
 
-  return {
-    englishDefinition: segments[0],
-    chineseTranslation: segments.slice(1).join("\n"),
-  };
+  if (legacyEnglish) {
+    const firstChinese = senses.find((sense) => sense.chinese && !sense.english);
+    if (firstChinese) {
+      firstChinese.english = legacyEnglish;
+    } else {
+      senses.unshift({ pos: "", chinese: "", english: legacyEnglish });
+    }
+  }
+
+  return { senses };
+};
+
+export const formatSenses = (senses: WordSense[]): string => {
+  return senses
+    .map((sense) => {
+      const head = [sense.pos, sense.chinese].filter(Boolean).join(" ");
+      const english = sense.english ? (head ? ` — ${sense.english}` : sense.english) : "";
+      return `${head}${english}`.trim();
+    })
+    .join("\n");
 };

--- a/apps/web/src/lib/wordsStore.test.ts
+++ b/apps/web/src/lib/wordsStore.test.ts
@@ -199,7 +199,12 @@ describe("mergeSnapshotIntoStore", () => {
   const makeSnapshot = (entries: Array<[string, Partial<WordData>]>) => ({
     docs: entries.map(([word, overrides]) => ({
       id: overrides.id ?? `id-${word}`,
-      data: () => ({ word, translation: overrides.translation ?? `${word}译`, ...overrides }),
+      data: () => ({
+        word,
+        translation: overrides.translation ?? `${word}译`,
+        ...overrides,
+        createdAt: overrides.createdAt ?? { toDate: () => new Date("2026-01-01T00:00:00") },
+      }),
     })),
   });
 

--- a/apps/web/src/lib/wordsStore.ts
+++ b/apps/web/src/lib/wordsStore.ts
@@ -195,12 +195,6 @@ export class Words {
     return this.wordData.get(word)?.translation;
   }
 
-  updateTranslation(word: string, translation: string) {
-    const data = this.wordData.get(word);
-    if (!data) return;
-    data.translation = translation;
-  }
-
   setUserInput(word: string, value: string) {
     this.userInputs.set(word, value);
   }


### PR DESCRIPTION
## 改动

**多义项（添加单词）**
- `/api/translate` 改为返回结构化 `senses: [{ pos, chinese, english }]`，2~4 个义项、最常用在前，并带长度校验
- `add-word` 页用 `formatSenses` 拼成每义项一行的字符串存储（`v. 吐（口水）；喷出 — to force liquid from the mouth`）
- 单词列表每义项一行展示词性+中文+英文

**删除双击编辑翻译**
- 移除单词列表双击编辑翻译功能及相关 UI
- 删除 `updateTranslation` 死代码（`useFirestoreWords` / `wordsStore` / i18n 文案）

**存量数据（方案 C）**
- 不批量迁移 Firestore；`parseTranslation` 兼容旧格式（首行英文、其余中文），老词条照常显示，仅新添加的单词用新格式

## 附带
- `sentence/generate` 的 translation 长度上限放宽，避免多义项文本误报「输入过长」

## 验证
- `bun run test`：68 个用例全过（含 formatSenses 往返解析）
- `bun x tsc --noEmit` 无错误
- `bun run lint` 通过