### PR TITLE
feat(web): 全站双击英文单词弹出添加确认弹窗

### DIFF
--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -17,6 +17,12 @@
 - `syncToFirestore` 落库的 `lastPracticedAt` 取同步队列条目的 `timestamp`（即真实练习时刻），不要用同步时的 `new Date()`。
 - 练习页的输入值在 `words.userInputs` 中，单词行是独立的 observer 组件（`WordRow`），只有对应行会随击键重渲染，不要在父组件渲染路径里读 `userInputs`。
 
+## 双击选词添加（Word Picker）
+
+- 全站任意页面双击英文单词会弹出添加确认弹窗（`src/components/word-picker/WordPicker.tsx` 在根 layout 挂载监听 `dblclick`，用 `window.getSelection()` 取词）。交互与词库校验的纯逻辑在 `src/lib/wordSelection.ts`（`extractWordFromSelection`/`checkWordAddable`，配套测试）。
+- 添加弹窗复用共享组件 `src/components/word-picker/AddWordDialog.tsx`（翻译 → 展示义项 → 确认落库），`/add-word` 页面与全局双击入口共用，不要在别处再复制「调 `/api/translate` + 确认弹窗」逻辑。弹窗内部只做翻译与落库，已存在/非法字符的预校验由调用方（页面或 `WordPicker`）先用 `checkWordAddable` 完成。
+- 双击监听需跳过 `input/textarea/select/[contenteditable]` 与弹窗自身（`[data-slot="dialog-content"]`），未登录时忽略；不要在这些区域或未登录场景触发。
+
 ## 多语言
 
 - locale 持久化在 cookie（`locale=zh|en`）：`layout.tsx` 服务端读 cookie（无 cookie 时回退 `accept-language`）决定 `<html lang>` 并通过 `LocaleProvider` 下发初始 locale；`useLocale` 的 `getServerSnapshot` 用该初始值，保证 SSR 与客户端一致。不要再从 localStorage 或硬编码读取 locale。

--- a/apps/web/src/app/add-word/page.tsx
+++ b/apps/web/src/app/add-word/page.tsx
@@ -1,25 +1,17 @@
 "use client";
 
-import { Button, Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle, Input } from "@/components/ui";
+import { Button, Input } from "@/components/ui";
+import { AddWordDialog } from "@/components/word-picker";
 import { useRef, useState } from "react";
 import Link from "next/link";
 import { useFirestoreWords, useLocale, toast } from "@/hooks";
-import { auth } from "@/lib/firebase";
-import { formatSenses, type WordSense } from "@/lib/parseTranslation";
-
-interface PendingWord {
-  word: string;
-  senses: WordSense[];
-}
+import { checkWordAddable } from "@/lib/wordSelection";
 
 const Home = () => {
-  const { words, addWord, loading: wordsLoading, error: wordsError } = useFirestoreWords();
+  const { words, loading: wordsLoading, error: wordsError } = useFirestoreWords();
   const { t } = useLocale();
   const [word, setWord] = useState("");
-  const [loading, setLoading] = useState(false);
-  const [confirming, setConfirming] = useState(false);
-  const [pending, setPending] = useState<PendingWord | null>(null);
-  const [dialogOpen, setDialogOpen] = useState(false);
+  const [pendingWord, setPendingWord] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
   const clear = () => {
@@ -27,86 +19,22 @@ const Home = () => {
     inputRef.current?.focus();
   };
 
-  const handleConfirmAdd = async () => {
-    if (!pending) return;
-
-    setConfirming(true);
-    const combinedTranslation = formatSenses(pending.senses);
-
-    try {
-      await addWord(pending.word, combinedTranslation);
-      setDialogOpen(false);
-      setPending(null);
-      clear();
-    } catch (error) {
-      console.error("Failed to add word:", error);
-      toast({ title: error instanceof Error ? error.message : t('addWord.addFailed'), variant: "destructive" });
-    } finally {
-      setConfirming(false);
-    }
-  };
-
-  const handleAddWord = async () => {
+  const handleAddWord = () => {
     if (!word) return;
 
-    setLoading(true);
-
-    if (words.wordData.has(word)) {
+    const status = checkWordAddable(words, word);
+    if (status === "exists") {
       toast({ title: t('addWord.wordExists').replace('{word}', word), variant: "destructive" });
       clear();
-      setLoading(false);
       return;
     }
-
-    if (!/^[a-zA-Z]+$/.test(word)) {
+    if (status === "invalid") {
       toast({ title: t('addWord.invalidChars').replace('{word}', word), variant: "destructive" });
       clear();
-      setLoading(false);
       return;
     }
 
-    try {
-      const idToken = await auth.currentUser?.getIdToken();
-      if (!idToken) {
-        throw new Error(t('error.notAuthenticated'));
-      }
-
-      const response = await fetch('/api/translate', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${idToken}`,
-        },
-        body: JSON.stringify({ word }),
-      });
-
-      const data = await response.json().catch(() => null);
-      if (!response.ok) {
-        throw new Error(data && typeof data.error === 'string' ? data.error : t('addWord.addFailed'));
-      }
-
-      const { senses } = data as {
-        senses: WordSense[] | null;
-      };
-
-      if (!senses || senses.length === 0) {
-        toast({ title: t('addWord.notRecognized').replace('{word}', word), variant: "destructive" });
-        clear();
-        setLoading(false);
-        return;
-      }
-
-      setPending({
-        word,
-        senses,
-      });
-      setDialogOpen(true);
-    } catch (error) {
-      console.error("Failed to add word:", error);
-      toast({ title: error instanceof Error ? error.message : t('addWord.addFailed'), variant: "destructive" });
-    } finally {
-      setLoading(false);
-    }
+    setPendingWord(word);
   };
 
   if (wordsLoading) {
@@ -140,7 +68,7 @@ const Home = () => {
         }}
       >
         <Input className="w-48" placeholder={t('addWord.word')} value={word} onChange={(e) => setWord(e.target.value.toLowerCase())} ref={inputRef} />
-        <Button onClick={handleAddWord} disabled={loading || dialogOpen}>
+        <Button onClick={handleAddWord}>
           {t('addWord.add')}
         </Button>
         <Button render={<Link href="/home" />} nativeButton={false}>
@@ -150,31 +78,14 @@ const Home = () => {
           {t('menu.profile')}
         </Button>
       </form>
-      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>
-              {t('addWord.confirmTitle')}: {pending?.word}
-            </DialogTitle>
-          </DialogHeader>
-          {pending && (
-            <div className="space-y-3">
-              <div>
-                <div className="text-sm font-medium">{t('addWord.confirmSenses')}</div>
-                <div className="text-sm text-muted-foreground whitespace-pre-line">{formatSenses(pending.senses)}</div>
-              </div>
-            </div>
-          )}
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setDialogOpen(false)}>
-              {t('addWord.cancel')}
-            </Button>
-            <Button onClick={handleConfirmAdd} disabled={confirming}>
-              {t('addWord.confirmAdd')}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <AddWordDialog
+        word={pendingWord}
+        onClose={() => setPendingWord(null)}
+        onFinished={() => {
+          setPendingWord(null);
+          clear();
+        }}
+      />
     </main>
   );
 };

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -8,6 +8,7 @@ import type { Metadata } from "next";
 import { FC, ReactNode } from "react";
 import { AuthProvider } from "@/components/auth";
 import { AppShell } from "@/components/auth/AppShell";
+import { WordPicker } from "@/components/word-picker";
 import { WordsProvider, LocaleProvider } from "@/hooks";
 import { Toaster } from "@/components/ui";
 import { detectLocaleFromAcceptLanguage, localeToHtmlLang } from "@/lib/i18n";
@@ -40,6 +41,7 @@ const RootLayout: FC<{ children: ReactNode }> = async ({ children }) => {
               <AppShell>
                 {children}
               </AppShell>
+              <WordPicker />
               <Toaster position="bottom-right" duration={5000} richColors />
             </WordsProvider>
           </AuthProvider>

--- a/apps/web/src/components/word-picker/AddWordDialog.tsx
+++ b/apps/web/src/components/word-picker/AddWordDialog.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui";
+import { useEffect, useRef, useState } from "react";
+import { useFirestoreWords, useLocale, toast } from "@/hooks";
+import { auth } from "@/lib/firebase";
+import { formatSenses, type WordSense } from "@/lib/parseTranslation";
+
+interface AddWordDialogProps {
+  word: string | null;
+  onClose: () => void;
+  onFinished?: () => void;
+}
+
+type Status = "loading" | "ready";
+
+const AddWordDialog = ({ word, onClose, onFinished }: AddWordDialogProps) => {
+  const { words, addWord } = useFirestoreWords();
+  const { t } = useLocale();
+  const [status, setStatus] = useState<Status>("loading");
+  const [senses, setSenses] = useState<WordSense[]>([]);
+  const [confirming, setConfirming] = useState(false);
+  const tRef = useRef(t);
+  tRef.current = t;
+  const onFinishedRef = useRef(onFinished);
+  onFinishedRef.current = onFinished;
+
+  useEffect(() => {
+    if (!word) {
+      setStatus("loading");
+      setSenses([]);
+      return;
+    }
+
+    let cancelled = false;
+
+    const run = async () => {
+      setStatus("loading");
+      setSenses([]);
+      const t = tRef.current;
+      try {
+        const idToken = await auth.currentUser?.getIdToken();
+        if (!idToken) {
+          throw new Error(t("error.notAuthenticated"));
+        }
+
+        const response = await fetch("/api/translate", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${idToken}`,
+          },
+          body: JSON.stringify({ word }),
+        });
+
+        const data = await response.json().catch(() => null);
+        if (!response.ok) {
+          throw new Error(
+            data && typeof data.error === "string"
+              ? data.error
+              : t("addWord.addFailed")
+          );
+        }
+
+        const fetched = (data as { senses: WordSense[] | null }).senses;
+        if (!fetched || fetched.length === 0) {
+          toast({
+            title: t("addWord.notRecognized").replace("{word}", word),
+            variant: "destructive",
+          });
+          onFinishedRef.current?.();
+          return;
+        }
+
+        if (cancelled) return;
+        setSenses(fetched);
+        setStatus("ready");
+      } catch (error) {
+        if (cancelled) return;
+        console.error("Failed to translate word:", error);
+        toast({
+          title:
+            error instanceof Error ? error.message : t("addWord.addFailed"),
+          variant: "destructive",
+        });
+        onFinishedRef.current?.();
+      }
+    };
+
+    run();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [word]);
+
+  const handleConfirmAdd = async () => {
+    if (!word || status !== "ready") return;
+
+    if (words.wordData.has(word)) {
+      toast({
+        title: tRef.current("addWord.wordExists").replace("{word}", word),
+        variant: "destructive",
+      });
+      onFinishedRef.current?.();
+      return;
+    }
+
+    setConfirming(true);
+    try {
+      await addWord(word, formatSenses(senses));
+      toast({ title: tRef.current("addWord.addSuccess"), variant: "success" });
+      onFinishedRef.current?.();
+    } catch (error) {
+      console.error("Failed to add word:", error);
+      toast({
+        title:
+          error instanceof Error
+            ? error.message
+            : tRef.current("addWord.addFailed"),
+        variant: "destructive",
+      });
+    } finally {
+      setConfirming(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open={word !== null}
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>
+            {status === "ready" && word
+              ? `${t("addWord.confirmTitle")}: ${word}`
+              : t("addWord.title")}
+          </DialogTitle>
+        </DialogHeader>
+        {status === "loading" && (
+          <div className="text-sm text-muted-foreground">
+            {t("common.loading")}
+          </div>
+        )}
+        {status === "ready" && (
+          <div className="space-y-3">
+            <div>
+              <div className="text-sm font-medium">
+                {t("addWord.confirmSenses")}
+              </div>
+              <div className="text-sm text-muted-foreground whitespace-pre-line">
+                {formatSenses(senses)}
+              </div>
+            </div>
+          </div>
+        )}
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose}>
+            {t("addWord.cancel")}
+          </Button>
+          {status === "ready" && (
+            <Button onClick={handleConfirmAdd} disabled={confirming}>
+              {t("addWord.confirmAdd")}
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default AddWordDialog;

--- a/apps/web/src/components/word-picker/WordPicker.tsx
+++ b/apps/web/src/components/word-picker/WordPicker.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useFirestoreWords, useLocale, useAuth, toast } from "@/hooks";
+import {
+  checkWordAddable,
+  extractWordFromSelection,
+} from "@/lib/wordSelection";
+import AddWordDialog from "./AddWordDialog";
+
+const EXCLUDED_SELECTOR =
+  'input, textarea, select, [contenteditable], [data-slot="dialog-content"]';
+
+const WordPicker = () => {
+  const { user } = useAuth();
+  const { words } = useFirestoreWords();
+  const { t } = useLocale();
+  const [word, setWord] = useState<string | null>(null);
+  const wordRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    wordRef.current = word;
+  }, [word]);
+
+  useEffect(() => {
+    const handleDoubleClick = (event: MouseEvent) => {
+      if (wordRef.current) return;
+      if (!user) return;
+
+      const target = event.target as Element | null;
+      if (!target) return;
+      if (target.closest(EXCLUDED_SELECTOR)) return;
+
+      const selection = window.getSelection();
+      const extracted = extractWordFromSelection(selection?.toString() ?? "");
+      if (!extracted) return;
+
+      const status = checkWordAddable(words, extracted);
+      if (status === "exists") {
+        toast({
+          title: t("addWord.wordExists").replace("{word}", extracted),
+          variant: "destructive",
+        });
+        return;
+      }
+      if (status === "invalid") {
+        toast({
+          title: t("addWord.invalidChars").replace("{word}", extracted),
+          variant: "destructive",
+        });
+        return;
+      }
+
+      setWord(extracted);
+    };
+
+    document.addEventListener("dblclick", handleDoubleClick);
+    return () => document.removeEventListener("dblclick", handleDoubleClick);
+  }, [user, words, t]);
+
+  return (
+    <AddWordDialog
+      word={word}
+      onClose={() => setWord(null)}
+      onFinished={() => setWord(null)}
+    />
+  );
+};
+
+export default WordPicker;

--- a/apps/web/src/components/word-picker/index.ts
+++ b/apps/web/src/components/word-picker/index.ts
@@ -1,0 +1,2 @@
+export { default as AddWordDialog } from "./AddWordDialog";
+export { default as WordPicker } from "./WordPicker";

--- a/apps/web/src/lib/i18n.ts
+++ b/apps/web/src/lib/i18n.ts
@@ -127,6 +127,7 @@ export const translations = {
     'addWord.confirmSenses': '词义',
     'addWord.confirmAdd': '确认添加',
     'addWord.cancel': '取消',
+    'addWord.addSuccess': '单词已添加',
 
     // Sync indicator
     'sync.pending': '个单词待同步',
@@ -246,6 +247,7 @@ export const translations = {
     'addWord.confirmSenses': 'Senses',
     'addWord.confirmAdd': 'Add',
     'addWord.cancel': 'Cancel',
+    'addWord.addSuccess': 'Word added',
 
     // Sync indicator
     'sync.pending': 'words pending',

--- a/apps/web/src/lib/wordSelection.test.ts
+++ b/apps/web/src/lib/wordSelection.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { Words } from "./wordsStore";
+import {
+  extractWordFromSelection,
+  checkWordAddable,
+  MAX_ADD_WORD_LENGTH,
+} from "./wordSelection";
+
+describe("extractWordFromSelection", () => {
+  it("提取普通英文单词并转小写", () => {
+    expect(extractWordFromSelection("Hello")).toBe("hello");
+    expect(extractWordFromSelection("APPLE")).toBe("apple");
+  });
+
+  it("从带标点/引号的选中文本中提取首个英文片段", () => {
+    expect(extractWordFromSelection('"world"')).toBe("world");
+    expect(extractWordFromSelection("can't")).toBe("can");
+    expect(extractWordFromSelection("well-known")).toBe("well");
+    expect(extractWordFromSelection("(run) fast")).toBe("run");
+  });
+
+  it("返回 null 的情况", () => {
+    expect(extractWordFromSelection("")).toBeNull();
+    expect(extractWordFromSelection("你好世界")).toBeNull();
+    expect(extractWordFromSelection("  ")).toBeNull();
+  });
+
+  it("超长文本返回 null", () => {
+    expect(extractWordFromSelection("a".repeat(MAX_ADD_WORD_LENGTH + 1))).toBeNull();
+  });
+});
+
+describe("checkWordAddable", () => {
+  it("新单词返回 ok", () => {
+    const words = new Words();
+    expect(checkWordAddable(words, "hello")).toBe("ok");
+  });
+
+  it("已存在返回 exists", () => {
+    const words = new Words();
+    words.addWord("hello", "你好", "id-1");
+    expect(checkWordAddable(words, "hello")).toBe("exists");
+  });
+
+  it("包含非法字符或超长返回 invalid", () => {
+    const words = new Words();
+    expect(checkWordAddable(words, "hello world")).toBe("invalid");
+    expect(checkWordAddable(words, "hello!")).toBe("invalid");
+    expect(checkWordAddable(words, "hello123")).toBe("invalid");
+    expect(checkWordAddable(words, "a".repeat(MAX_ADD_WORD_LENGTH + 1))).toBe("invalid");
+  });
+});

--- a/apps/web/src/lib/wordSelection.ts
+++ b/apps/web/src/lib/wordSelection.ts
@@ -1,0 +1,27 @@
+import type { Words } from "@/lib/wordsStore";
+
+export const MAX_ADD_WORD_LENGTH = 50;
+
+const WORD_RUN_PATTERN = /[a-zA-Z]+/;
+
+export const extractWordFromSelection = (text: string): string | null => {
+  if (!text) return null;
+  const match = text.match(WORD_RUN_PATTERN);
+  if (!match) return null;
+  const word = match[0].toLowerCase();
+  if (word.length > MAX_ADD_WORD_LENGTH) return null;
+  return word;
+};
+
+export type WordAddableStatus = "ok" | "exists" | "invalid";
+
+export const checkWordAddable = (
+  words: Words,
+  word: string
+): WordAddableStatus => {
+  if (words.wordData.has(word)) return "exists";
+  if (!/^[a-zA-Z]+$/.test(word) || word.length > MAX_ADD_WORD_LENGTH) {
+    return "invalid";
+  }
+  return "ok";
+};


### PR DESCRIPTION
## 变更内容

在网站任意页面双击英文单词，弹出与 `/add-word` 一致的添加确认弹窗，点击确认即可加入词库。

- **全局触发**：新增 `WordPicker` 组件挂载在根 layout，监听 `dblclick`，通过 `window.getSelection()` 取词；跳过输入框/`contenteditable`/弹窗自身，未登录时忽略。
- **共享弹窗**：抽出 `AddWordDialog`（翻译 → 展示义项 → 确认落库），`/add-word` 页面与全局双击入口共用，删除页面内重复逻辑。
- **纯逻辑**：`lib/wordSelection.ts`（`extractWordFromSelection` / `checkWordAddable`），附带 vitest 单测。
- **交互细节**：已存在/非法字符 toast 提示不弹窗；未识别或翻译失败 toast 提示并关闭；确认添加成功 toast「单词已添加」。

## 验证

- `bun run test`：75 项测试全部通过（含新增 wordSelection 测试）
- `bun run lint`、`tsc --noEmit` 通过