### PR TITLE
feat(web): Profile 页支持 AI 重新生成全部单词释义

### DIFF
--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -15,6 +15,7 @@
 - Firestore `onSnapshot` 结果通过 `mergeSnapshotIntoStore(store, snapshot)` 增量合并到 store（仅更新变化的单词、按需使缓存失效），不要改成全量替换 `wordData`，否则会导致所有 observer 组件无谓重渲染。
 - `correctPracticeDates` 存 `YYYY-MM-DD` 本地日期字符串（`formatLocalPracticeDate`），不要存 ISO 时间戳，避免时区解析偏移；`getLocalPracticeDate` 对纯日期字符串短路返回。
 - `syncToFirestore` 落库的 `lastPracticedAt` 取同步队列条目的 `timestamp`（即真实练习时刻），不要用同步时的 `new Date()`。
+- 批量更新释义用 `updateTranslations(updates)`：先 `setWordData` 即时更新 store（失效缓存），再按 wordId 用 `commitBatchOperations` 写 Firestore（onSnapshot 幂等合并）。
 - 练习页的输入值在 `words.userInputs` 中，单词行是独立的 observer 组件（`WordRow`），只有对应行会随击键重渲染，不要在父组件渲染路径里读 `userInputs`。
 
 ## 双击选词添加（Word Picker）
@@ -40,4 +41,5 @@
 - 同步队列（`src/lib/syncQueue.ts`）条目重试达到上限被丢弃时，`incrementRetries` 返回被丢弃条目，`syncToFirestore` 会 toast 提示用户（文案 `sync.dataLost`），不要改回静默丢弃。
 - 造句题目界面不直接显示目标单词（答题后的反馈区才显示），这是有意设计：学生凭中文句子推断用词，因此造句请求会把词库中存的中文译法随目标词一并传给模型，prompt 要求中文译文自然地道、使用参考译法且能让学生反推出目标词；批改时对目标词的同义表达不判错、仅提示。
 - 批改接口在调用模型前先对答案与参考译文做规范化判等（`src/lib/sentenceCompare.ts` 的 `normalizeForComparison`），完全一致直接返回满分，不消耗模型调用。
+- `/api/regenerate-definitions` 批量重新生成释义：请求 `{ words: string[] }`（每批上限 50，服务端会过滤掉非小写字母或超长词并去重，合法词为空时 400），一次 DeepSeek 调用返回 `{ results: [{ word, senses }] }`；纯逻辑在 `src/lib/regenerateDefinitions.ts`（`buildRegenerateMessages`/`parseRegenerateResults`，配套测试），未识别或非法的词 `senses` 为 `null`，前端保留原释义。Profile 页「AI 重新生成释义」前端串行分批调用并显示进度，通过 `useFirestoreWords` 的 `updateTranslations`（store 即时更新 + Firestore batch 写 `translation`）落库，不改动练习数据。
 - 纯函数测试用 vitest（`bun run test`，配置在 `vitest.config.mts`），核心算法（熟练度、翻译解析、句意判等、日期处理）新增改动时应同步补测试。

--- a/apps/web/src/app/api/regenerate-definitions/route.ts
+++ b/apps/web/src/app/api/regenerate-definitions/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse } from "next/server";
+import { verifyFirebaseIdToken } from "@/lib/serverAuth";
+import { checkRateLimit } from "@/lib/rateLimit";
+import { chatCompletionJson, DeepSeekError } from "@/lib/deepseek";
+import {
+  buildRegenerateMessages,
+  parseRegenerateResults,
+  MAX_REGENERATE_BATCH_SIZE,
+} from "@/lib/regenerateDefinitions";
+
+const WORD_PATTERN = /^[a-z]+$/;
+const MAX_WORD_LENGTH = 50;
+const RATE_LIMIT_PER_MINUTE = 60;
+const RATE_LIMIT_WINDOW_MS = 60 * 1000;
+
+export async function POST(request: Request) {
+  const auth = await verifyFirebaseIdToken(request);
+  if (auth instanceof NextResponse) return auth;
+
+  const rateLimitError = await checkRateLimit(
+    `${auth.uid}:regenerate`,
+    RATE_LIMIT_PER_MINUTE,
+    RATE_LIMIT_WINDOW_MS
+  );
+  if (rateLimitError) return rateLimitError;
+
+  let body: { words?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "请求格式错误" }, { status: 400 });
+  }
+
+  if (!Array.isArray(body.words) || body.words.length === 0) {
+    return NextResponse.json({ error: "无效单词列表" }, { status: 400 });
+  }
+  if (body.words.length > MAX_REGENERATE_BATCH_SIZE) {
+    return NextResponse.json({ error: "单词数量过多" }, { status: 400 });
+  }
+
+  const words: string[] = [];
+  for (const raw of body.words) {
+    const word = typeof raw === "string" ? raw.trim().toLowerCase() : "";
+    if (WORD_PATTERN.test(word) && word.length <= MAX_WORD_LENGTH) {
+      words.push(word);
+    }
+  }
+  if (words.length === 0) {
+    return NextResponse.json({ error: "无效单词列表" }, { status: 400 });
+  }
+  const uniqueWords = Array.from(new Set(words));
+
+  try {
+    const raw = await chatCompletionJson<unknown>(
+      buildRegenerateMessages(uniqueWords),
+      { temperature: 0.2 }
+    );
+    return NextResponse.json({
+      results: parseRegenerateResults(raw, uniqueWords),
+    });
+  } catch (error) {
+    console.error("regenerate definitions failed:", error);
+    if (error instanceof DeepSeekError) {
+      return NextResponse.json({ error: error.message }, { status: error.status });
+    }
+    return NextResponse.json(
+      { error: "重新生成释义失败，请稍后重试" },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -297,7 +297,7 @@ const Profile = observer(() => {
           </div>
 
           {/* AI Regenerate Definitions */}
-          <div className="border-t border-gray-200 dark:border-gray-700 pt-6">
+          <div className="border-t border-gray-200 dark:border-gray-700 pt-6 mb-6">
             <h3 className="text-lg font-semibold mb-2">{t('profile.regenerateTitle')}</h3>
             <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
               {t('profile.regenerateDesc')}

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -4,8 +4,14 @@ import { Button, ConfirmDialog, Input, MasteryBar } from "@/components/ui";
 import { useFirestoreWords, useLocale, toast, useAuth } from "@/hooks";
 import { observer } from "mobx-react-lite";
 import Link from "next/link";
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useRef } from "react";
 import { type Locale } from "@/lib/i18n";
+import { auth } from "@/lib/firebase";
+import { formatSenses } from "@/lib/parseTranslation";
+import {
+  MAX_REGENERATE_BATCH_SIZE,
+  type RegenerateResult,
+} from "@/lib/regenerateDefinitions";
 
 const COLOR_CLASSES = {
   blue: {
@@ -24,7 +30,7 @@ const COLOR_CLASSES = {
 
 const Profile = observer(() => {
   const { user } = useAuth();
-  const { words, deleteWord, resetPracticeRecords, loading, error } =
+  const { words, deleteWord, resetPracticeRecords, updateTranslations, loading, error } =
     useFirestoreWords();
   const [isClient, setIsClient] = useState(false);
   const { locale, setLocale, t } = useLocale();
@@ -33,6 +39,10 @@ const Profile = observer(() => {
   const [searchQuery, setSearchQuery] = useState("");
   const [wordToDelete, setWordToDelete] = useState<string | null>(null);
   const [deleting, setDeleting] = useState(false);
+  const [showRegenerateDialog, setShowRegenerateDialog] = useState(false);
+  const [regenerating, setRegenerating] = useState(false);
+  const [regenerateProgress, setRegenerateProgress] = useState(0);
+  const regeneratingRef = useRef(false);
 
   useEffect(() => {
     setIsClient(true);
@@ -123,6 +133,106 @@ const Profile = observer(() => {
     }
   };
 
+  const handleRegenerateAll = async () => {
+    if (regeneratingRef.current) return;
+    regeneratingRef.current = true;
+
+    const allWords = Array.from(words.wordData.keys());
+    if (allWords.length === 0) {
+      regeneratingRef.current = false;
+      return;
+    }
+
+    setRegenerating(true);
+    setRegenerateProgress(0);
+    const total = allWords.length;
+    let success = 0;
+    let skipped = 0;
+    let batchFailed = 0;
+    const batches: string[][] = [];
+
+    try {
+      const idToken = await auth.currentUser?.getIdToken();
+      if (!idToken) {
+        throw new Error(t('error.notAuthenticated'));
+      }
+
+      for (let i = 0; i < total; i += MAX_REGENERATE_BATCH_SIZE) {
+        batches.push(allWords.slice(i, i + MAX_REGENERATE_BATCH_SIZE));
+      }
+
+      for (const batch of batches) {
+        let batchSuccess = 0;
+        try {
+          const response = await fetch("/api/regenerate-definitions", {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${idToken}`,
+            },
+            body: JSON.stringify({ words: batch }),
+          });
+
+          const data = await response.json().catch(() => null);
+          if (!response.ok) {
+            throw new Error(
+              data && typeof data.error === "string"
+                ? data.error
+                : t('profile.regenerateFailed')
+            );
+          }
+
+          const results = (data as { results?: RegenerateResult[] } | null)?.results ?? [];
+          const updates: Array<{ word: string; translation: string }> = [];
+          for (const item of results) {
+            if (item.senses && item.senses.length > 0) {
+              updates.push({ word: item.word, translation: formatSenses(item.senses) });
+              batchSuccess += 1;
+            }
+          }
+          if (updates.length > 0) {
+            await updateTranslations(updates);
+          }
+          success += batchSuccess;
+          skipped += batch.length - batchSuccess;
+        } catch (err) {
+          console.error("Regenerate batch failed:", err);
+          batchFailed += batch.length;
+          skipped += batch.length;
+        }
+        setRegenerateProgress((prev) => prev + batch.length);
+      }
+
+      if (batchFailed === total) {
+        toast({
+          title: t('profile.regenerateFailed'),
+          variant: "destructive",
+        });
+      } else if (skipped > 0) {
+        toast({
+          title: t('profile.regeneratePartial').replace('{success}', String(success)).replace('{skipped}', String(skipped)),
+          variant: "success",
+        });
+      } else {
+        toast({
+          title: t('profile.regenerateSuccess').replace('{success}', String(success)),
+          variant: "success",
+        });
+      }
+    } catch (err) {
+      console.error("Regenerate all failed:", err);
+      toast({
+        title:
+          err instanceof Error ? err.message : t('profile.regenerateFailed'),
+        variant: "destructive",
+      });
+    } finally {
+      regeneratingRef.current = false;
+      setRegenerating(false);
+      setShowRegenerateDialog(false);
+    }
+  };
+
   if (loading) {
     return (
       <main>
@@ -184,6 +294,23 @@ const Profile = observer(() => {
                 English
               </button>
             </div>
+          </div>
+
+          {/* AI Regenerate Definitions */}
+          <div className="border-t border-gray-200 dark:border-gray-700 pt-6">
+            <h3 className="text-lg font-semibold mb-2">{t('profile.regenerateTitle')}</h3>
+            <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+              {t('profile.regenerateDesc')}
+            </p>
+            <Button
+              variant="outline"
+              onClick={() => setShowRegenerateDialog(true)}
+              disabled={regenerating || totalWords === 0}
+            >
+              {regenerating
+                ? `${t('common.loading')} ${regenerateProgress}/${totalWords}`
+                : t('profile.regenerateButton')}
+            </Button>
           </div>
 
           {/* Reset Practice Records */}
@@ -351,6 +478,18 @@ const Profile = observer(() => {
           cancelText={t('common.cancel')}
           onConfirm={handleResetRecords}
           variant="destructive"
+        />
+
+        {/* Regenerate Definitions Confirmation Dialog */}
+        <ConfirmDialog
+          open={showRegenerateDialog}
+          onOpenChange={setShowRegenerateDialog}
+          title={t('profile.regenerateConfirm')}
+          description={t('profile.regenerateConfirmDesc')}
+          confirmText={t('common.confirm')}
+          cancelText={t('common.cancel')}
+          onConfirm={handleRegenerateAll}
+          variant="default"
         />
 
         {/* Delete Word Confirmation Dialog */}

--- a/apps/web/src/hooks/useFirestoreWords.tsx
+++ b/apps/web/src/hooks/useFirestoreWords.tsx
@@ -59,6 +59,9 @@ interface WordsContextValue {
   recordIncorrectAttempt: (word: string) => void;
   syncToFirestore: () => Promise<void>;
   resetPracticeRecords: () => Promise<void>;
+  updateTranslations: (
+    updates: Array<{ word: string; translation: string }>
+  ) => Promise<void>;
   loading: boolean;
   error: string | null;
   syncing: boolean;
@@ -390,6 +393,48 @@ export const WordsProvider: FC<{ children: ReactNode }> = ({ children }) => {
     return () => window.removeEventListener("online", handleOnline);
   }, [syncToFirestore]);
 
+  const updateTranslations = useCallback(
+    async (updates: Array<{ word: string; translation: string }>) => {
+      if (!user) {
+        throw new Error(tError("error.notAuthenticated"));
+      }
+
+      if (updates.length === 0) return;
+
+      const userId = getEffectiveUserId(user);
+      const entries = updates
+        .map(({ word, translation }) => {
+          const data = words.wordData.get(word);
+          const wordId = data?.id;
+          if (!data || !wordId) return null;
+          return { word, translation, data, wordId };
+        })
+        .filter(
+          (entry): entry is NonNullable<typeof entry> => entry !== null
+        );
+
+      if (entries.length === 0) return;
+
+      try {
+        entries.forEach(({ word, translation, data }) => {
+          words.setWordData(word, { ...data, translation });
+        });
+
+        await commitBatchOperations(
+          entries.map(({ wordId, translation }) => (batch) => {
+            batch.update(doc(db, "users", userId, "words", wordId), {
+              translation,
+            });
+          })
+        );
+      } catch (err) {
+        console.error("Failed to update translations:", err);
+        throw new Error(tError("error.updateTranslationFailed"));
+      }
+    },
+    [user]
+  );
+
   const resetPracticeRecords = useCallback(async () => {
     if (!user) {
       throw new Error(tError("error.notAuthenticated"));
@@ -438,6 +483,7 @@ export const WordsProvider: FC<{ children: ReactNode }> = ({ children }) => {
       recordIncorrectAttempt,
       syncToFirestore,
       resetPracticeRecords,
+      updateTranslations,
       loading,
       error,
       syncing,
@@ -451,6 +497,7 @@ export const WordsProvider: FC<{ children: ReactNode }> = ({ children }) => {
       recordIncorrectAttempt,
       syncToFirestore,
       resetPracticeRecords,
+      updateTranslations,
       loading,
       error,
       syncing,

--- a/apps/web/src/lib/i18n.ts
+++ b/apps/web/src/lib/i18n.ts
@@ -47,6 +47,7 @@ export const translations = {
     'error.deleteWordFailed': '从云端删除单词失败',
     'error.removeWordsFailed': '从云端删除单词失败',
     'error.resetFailed': '重置练习记录失败',
+    'error.updateTranslationFailed': '更新释义失败，请稍后重试',
     'error.wordNotFound': '未找到单词',
     
     // Home page
@@ -114,6 +115,14 @@ export const translations = {
     'profile.deleteConfirmDesc': '这将同时删除该单词的所有练习记录，此操作不可撤销。',
     'profile.deleteSuccess': '单词已删除',
     'profile.deleteError': '删除失败，请重试',
+    'profile.regenerateTitle': 'AI 重新生成释义',
+    'profile.regenerateDesc': '让 AI 重新生成当前记录中所有单词的释义（不会删除或改变练习记录）。',
+    'profile.regenerateButton': '重新生成全部释义',
+    'profile.regenerateConfirm': '确定要重新生成全部单词的释义吗？',
+    'profile.regenerateConfirmDesc': 'AI 将重新生成当前记录中所有单词的释义，替换原有的释义。此操作会消耗一定时间，且不可撤销。',
+    'profile.regenerateSuccess': '已重新生成 {success} 个单词的释义',
+    'profile.regeneratePartial': '已重新生成 {success} 个单词的释义，{skipped} 个保留原释义',
+    'profile.regenerateFailed': '重新生成释义失败，请稍后重试',
 
     // Add Word page
     'addWord.title': '添加单词',
@@ -167,6 +176,7 @@ export const translations = {
     'error.deleteWordFailed': 'Failed to delete word from cloud',
     'error.removeWordsFailed': 'Failed to remove words from cloud',
     'error.resetFailed': 'Failed to reset practice records',
+    'error.updateTranslationFailed': 'Failed to update definitions, please try again',
     'error.wordNotFound': 'Word not found',
     
     // Home page
@@ -234,6 +244,14 @@ export const translations = {
     'profile.deleteConfirmDesc': 'This will also delete all practice records for this word. This action cannot be undone.',
     'profile.deleteSuccess': 'Word deleted',
     'profile.deleteError': 'Failed to delete, please try again',
+    'profile.regenerateTitle': 'Regenerate Definitions with AI',
+    'profile.regenerateDesc': 'Let AI regenerate the definitions of all words in the current records (practice records will not be deleted or changed).',
+    'profile.regenerateButton': 'Regenerate All Definitions',
+    'profile.regenerateConfirm': 'Regenerate definitions for all words?',
+    'profile.regenerateConfirmDesc': 'AI will regenerate the definitions of all words in the current records, replacing the existing ones. This takes some time and cannot be undone.',
+    'profile.regenerateSuccess': 'Regenerated definitions for {success} words',
+    'profile.regeneratePartial': 'Regenerated definitions for {success} words, kept {skipped} unchanged',
+    'profile.regenerateFailed': 'Failed to regenerate definitions, please try again',
 
     // Add Word page
     'addWord.title': 'Add Word',

--- a/apps/web/src/lib/regenerateDefinitions.test.ts
+++ b/apps/web/src/lib/regenerateDefinitions.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildRegenerateMessages,
+  parseRegenerateResults,
+  MAX_SENSES,
+} from "./regenerateDefinitions";
+
+describe("buildRegenerateMessages", () => {
+  it("构造 system 与 user 消息，包含全部单词", () => {
+    const messages = buildRegenerateMessages(["apple", "banana"]);
+    expect(messages).toHaveLength(2);
+    expect(messages[0].role).toBe("system");
+    expect(messages[1].role).toBe("user");
+    expect(messages[1].content).toBe("apple, banana");
+  });
+});
+
+describe("parseRegenerateResults", () => {
+  const requested = ["apple", "banana", "notaword"];
+
+  it("解析有效义项并保留顺序，缺失词 senses 为 null", () => {
+    const result = parseRegenerateResults(
+      {
+        results: [
+          {
+            word: "apple",
+            senses: [
+              { pos: "n.", chinese: "苹果", english: "a round fruit" },
+            ],
+          },
+          { word: "banana", senses: null },
+        ],
+      },
+      requested
+    );
+    expect(result).toEqual([
+      { word: "apple", senses: [{ pos: "n.", chinese: "苹果", english: "a round fruit" }] },
+      { word: "banana", senses: null },
+      { word: "notaword", senses: null },
+    ]);
+  });
+
+  it("过滤非法义项与非法词条", () => {
+    const result = parseRegenerateResults(
+      {
+        results: [
+          { word: "apple", senses: [{ pos: "", chinese: "苹果", english: "" }] },
+          { word: "  APPLE  ", senses: [{ pos: "n.", chinese: "苹果", english: "a round fruit" }] },
+        ],
+      },
+      ["apple"]
+    );
+    expect(result).toEqual([
+      { word: "apple", senses: [{ pos: "n.", chinese: "苹果", english: "a round fruit" }] },
+    ]);
+  });
+
+  it("超长义项被过滤，空数组视为 null", () => {
+    const result = parseRegenerateResults(
+      {
+        results: [
+          { word: "apple", senses: [] },
+          {
+            word: "banana",
+            senses: [{ pos: "n.", chinese: "x".repeat(51), english: "y".repeat(151) }],
+          },
+        ],
+      },
+      ["apple", "banana"]
+    );
+    expect(result).toEqual([
+      { word: "apple", senses: null },
+      { word: "banana", senses: null },
+    ]);
+  });
+
+  it("截断到 MAX_SENSES 个义项", () => {
+    const senses = Array.from({ length: MAX_SENSES + 2 }, (_, i) => ({
+      pos: "n.",
+      chinese: `义项${i}`,
+      english: `sense ${i}`,
+    }));
+    const result = parseRegenerateResults({ results: [{ word: "apple", senses }] }, ["apple"]);
+    expect(result[0].senses).toHaveLength(MAX_SENSES);
+  });
+
+  it("非对象或缺失 results 时全部为 null", () => {
+    expect(parseRegenerateResults(null, requested).every((r) => r.senses === null)).toBe(true);
+    expect(parseRegenerateResults({ foo: 1 }, requested).every((r) => r.senses === null)).toBe(true);
+  });
+});

--- a/apps/web/src/lib/regenerateDefinitions.ts
+++ b/apps/web/src/lib/regenerateDefinitions.ts
@@ -1,0 +1,82 @@
+import type { ChatMessage } from "@/lib/deepseek";
+import type { WordSense } from "@/lib/parseTranslation";
+
+export const MAX_SENSES = 4;
+export const MAX_POS_LENGTH = 10;
+export const MAX_DEFINITION_LENGTH = 150;
+export const MAX_TRANSLATION_LENGTH = 50;
+export const MAX_REGENERATE_BATCH_SIZE = 50;
+
+export interface RegenerateResult {
+  word: string;
+  senses: WordSense[] | null;
+}
+
+export const buildRegenerateMessages = (words: string[]): ChatMessage[] => [
+  {
+    role: "system",
+    content: [
+      "你是一位英语词典编辑。用户会给出若干英文单词，请为它们重新生成词典释义。",
+      "对每个单词，senses 为该词最常见到较常见的多个义项（通常 2-4 个），最常用的排在最前面；每个义项包含：",
+      "1. pos：简短词性标注（如 n.、v.、adj.、adv. 等）；",
+      "2. chinese：该义项最常用的中文译法，简洁（不超过 10 个字，有多个常用译法时用顿号分隔）；",
+      "3. english：该义项的学习型词典风格简短英文释义，一句话，不超过 15 个单词。",
+      "如果某个单词不是有效英文单词（拼写错误或生造词），senses 为 null。",
+      "必须为列表中的每个单词都返回一条结果，不要遗漏任何单词。",
+      '只返回 JSON，不要添加其它字段或解释：{"results": [{"word": "...", "senses": [{"pos": "...", "chinese": "...", "english": "..."}]}]}',
+    ].join("\n"),
+  },
+  { role: "user", content: words.join(", ") },
+];
+
+const sanitizeSenses = (value: unknown): WordSense[] | null => {
+  if (!Array.isArray(value) || value.length === 0) return null;
+
+  const senses: WordSense[] = [];
+  for (const raw of value.slice(0, MAX_SENSES)) {
+    if (typeof raw !== "object" || raw === null) continue;
+    const record = raw as Record<string, unknown>;
+    const pos = typeof record.pos === "string" ? record.pos.trim() : "";
+    const chinese = typeof record.chinese === "string" ? record.chinese.trim() : "";
+    const english = typeof record.english === "string" ? record.english.trim() : "";
+    if (
+      pos &&
+      pos.length <= MAX_POS_LENGTH &&
+      chinese &&
+      chinese.length <= MAX_TRANSLATION_LENGTH &&
+      english &&
+      english.length <= MAX_DEFINITION_LENGTH
+    ) {
+      senses.push({ pos, chinese, english });
+    }
+  }
+
+  return senses.length > 0 ? senses : null;
+};
+
+export const parseRegenerateResults = (
+  raw: unknown,
+  requestedWords: string[]
+): RegenerateResult[] => {
+  const results =
+    typeof raw === "object" &&
+    raw !== null &&
+    Array.isArray((raw as { results?: unknown }).results)
+      ? (raw as { results: unknown[] }).results
+      : [];
+
+  const byWord = new Map<string, WordSense[] | null>();
+  for (const item of results) {
+    if (typeof item !== "object" || item === null) continue;
+    const record = item as Record<string, unknown>;
+    const word =
+      typeof record.word === "string" ? record.word.trim().toLowerCase() : "";
+    if (!word) continue;
+    byWord.set(word, sanitizeSenses(record.senses));
+  }
+
+  return requestedWords.map((word) => ({
+    word,
+    senses: byWord.has(word) ? byWord.get(word) ?? null : null,
+  }));
+};


### PR DESCRIPTION
## 功能

Profile 页新增「AI 重新生成释义」功能：一键让 AI 重新生成当前记录中所有单词的释义（只更新 `translation` 字段，不改动练习数据）。

## 实现

- **新增批量 API** `/api/regenerate-definitions`：接收 `{ words: string[] }`（每批 ≤50，服务端过滤非小写字母/超长词并去重，合法词为空返回 400），一次 DeepSeek 调用批量生成释义，返回 `{ results: [{ word, senses }] }`；带 Firebase token 校验与按 uid 限流（60/min）。
- **纯逻辑** `src/lib/regenerateDefinitions.ts`：`buildRegenerateMessages` 构造 prompt、`parseRegenerateResults` 解析并校验模型返回（未识别/非法词 `senses` 为 `null`，前端保留原释义），配套 vitest 测试。
- **store 层** `useFirestoreWords` 新增 `updateTranslations`：先 `setWordData` 乐观更新 store（失效缓存），再按 wordId 用 Firestore batch 写 `translation`（onSnapshot 幂等合并）。
- **UI**（`profile/page.tsx`）：设置区新增按钮 + 确认弹窗，确认后串行分批调用并显示进度（`done/total`），失败批不中断，完成后 toast 汇总成功/保留数；`regeneratingRef` 防重复触发。
- **i18n**：中英两套文案。

## 验证

- `bun run test`：81 passed
- `tsc --noEmit`：通过
- `eslint`：通过

## 说明

- 重新生成失败（AI 未识别/接口错误）的单词保留原释义，不整体回滚。
- 每批上限 50，词库大时分批串行处理，避免触发限流并逐批反馈进度。