### PR TITLE
style(words): 优化单词练习页排版

### DIFF
--- a/apps/web/src/app/words/page.tsx
+++ b/apps/web/src/app/words/page.tsx
@@ -32,9 +32,9 @@ const WordRow = observer(({ word, translation, words, onInputChange, onHintRevea
         >
           {hasSense ? (
             senses.map((sense, index) => (
-              <span key={index} className="flex flex-col">
-                <span>{[sense.pos, sense.chinese].filter(Boolean).join(" ")}</span>
-                {sense.english && <span className="text-sm font-normal text-gray-500">{sense.english}</span>}
+              <span key={index}>
+                {[sense.pos, sense.chinese].filter(Boolean).join(" ")}
+                {sense.english && <span className="text-sm font-normal text-gray-500"> — {sense.english}</span>}
               </span>
             ))
           ) : (

--- a/apps/web/src/app/words/page.tsx
+++ b/apps/web/src/app/words/page.tsx
@@ -25,10 +25,10 @@ const WordRow = observer(({ word, translation, words, onInputChange, onHintRevea
   const hasSense = senses.some((sense) => sense.chinese);
 
   return (
-    <li className="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-x-2 gap-y-1">
-      <div className="max-w-xs w-full text-right justify-self-end">
+    <li className="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-x-2 gap-y-1 border-b border-gray-100 py-3 first:pt-0 last:border-b-0">
+      <div className="max-w-xs w-full justify-self-end text-left">
         <div
-          className={`min-h-9 px-3 py-1 flex flex-col items-end justify-start whitespace-pre-line ${hasSense ? "font-semibold" : "text-gray-400 italic"}`}
+          className={`min-h-8 px-3 py-1 flex flex-col items-start justify-start whitespace-pre-line ${hasSense ? "font-semibold" : "text-gray-400 italic"}`}
         >
           {hasSense ? (
             senses.map((sense, index) => (
@@ -218,7 +218,7 @@ const WordsPractice = observer(() => {
         <SyncIndicator syncing={syncing} pendingCount={pendingCount} onManualSync={syncToFirestore} />
         <main>
           <form onSubmit={handleSubmit} className="flex flex-col space-y-2">
-            <ul className="space-y-2">
+            <ul>
               {randomWords.map(([word, translation]) => (
                 <WordRow
                   key={word}

--- a/apps/web/src/app/words/page.tsx
+++ b/apps/web/src/app/words/page.tsx
@@ -32,9 +32,9 @@ const WordRow = observer(({ word, translation, words, onInputChange, onHintRevea
         >
           {hasSense ? (
             senses.map((sense, index) => (
-              <span key={index}>
-                {[sense.pos, sense.chinese].filter(Boolean).join(" ")}
-                {sense.english && <span className="text-sm font-normal text-gray-500"> — {sense.english}</span>}
+              <span key={index} className="flex flex-col">
+                <span>{[sense.pos, sense.chinese].filter(Boolean).join(" ")}</span>
+                {sense.english && <span className="text-sm font-normal text-gray-500">{sense.english}</span>}
               </span>
             ))
           ) : (


### PR DESCRIPTION
## 改动

保留「左释义、右输入」的现有结构，仅调整排版样式（无逻辑变更）：

- **释义左对齐**：释义块仍靠右贴近输入框，但内部多行文本改为左对齐，消除英文释义折行后的锯齿感
- **单词分组**：行间加细分隔线与行内距，区分「同一词的多义项」与「不同的词」
- **首行对齐**：释义首行高度与输入框对齐（`min-h-9` → `min-h-8`，匹配 Input 的 `h-8`）

## 验证

- `bun run test`：81 个测试全部通过
- ESLint 无告警